### PR TITLE
refactor: extract NOTE_COLORS to shared constants

### DIFF
--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { auth } from "@/auth"
 import { db } from "@/lib/db"
+import { NOTE_COLORS } from "@/lib/constants"
 
 // Get all notes for a board
 export async function GET(
@@ -96,19 +97,7 @@ export async function POST(
       return NextResponse.json({ error: "Access denied" }, { status: 403 })
     }
 
-    // Random colors for sticky notes
-    const colors = [
-      "#fef3c7", // yellow
-      "#fce7f3", // pink
-      "#dbeafe", // blue
-      "#dcfce7", // green
-      "#fed7d7", // red
-      "#e0e7ff", // indigo
-      "#f3e8ff", // purple
-      "#fef4e6", // orange
-    ]
-
-    const randomColor = color || colors[Math.floor(Math.random() * colors.length)]
+    const randomColor = color || NOTE_COLORS[Math.floor(Math.random() * NOTE_COLORS.length)]
 
     const note = await db.note.create({
       data: {

--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { auth } from "@/auth"
 import { db } from "@/lib/db"
+import { NOTE_COLORS } from "@/lib/constants"
 
 // Get all notes from all boards in the organization
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -92,19 +93,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 })
     }
 
-    // Random colors for sticky notes
-    const colors = [
-      "#fef3c7", // yellow
-      "#fce7f3", // pink
-      "#dbeafe", // blue
-      "#dcfce7", // green
-      "#fed7d7", // red
-      "#e0e7ff", // indigo
-      "#f3e8ff", // purple
-      "#fef4e6", // orange
-    ]
-
-    const randomColor = color || colors[Math.floor(Math.random() * colors.length)]
+    const randomColor = color || NOTE_COLORS[Math.floor(Math.random() * NOTE_COLORS.length)]
 
     const note = await db.note.create({
       data: {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,12 @@
+export const NOTE_COLORS = [
+  "#fef3c7", // yellow
+  "#fce7f3", // pink
+  "#dbeafe", // blue
+  "#dcfce7", // green
+  "#fed7d7", // red
+  "#e0e7ff", // indigo
+  "#f3e8ff", // purple
+  "#fef4e6", // orange
+] as const
+
+export type NoteColor = typeof NOTE_COLORS[number]


### PR DESCRIPTION
## Summary
Extracts duplicate color arrays into a shared constants file for better maintainability.

## What changed
- Created `lib/constants.ts` with `NOTE_COLORS` array
- Updated API routes to use the shared constant
- Removed 26 lines of duplicate code

## Impact
- **DRY principle**: Single source of truth for note colors
- **Easier maintenance**: Change colors in one place
- **Type safety**: Added `NoteColor` type for better TypeScript support

No functional changes - purely a refactoring.