### PR TITLE
Enhance: Make PostgreSQL port configurable using POSTGRES_PORT env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
 AUTH_SECRET=sample-auth-secret
 AUTH_RESEND_KEY=re_sample_key
+POSTGRES_PORT=5432
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/gumboard


### PR DESCRIPTION
### Summary
This PR makes the PostgreSQL port configurable via an environment variable `POSTGRES_PORT`.

### Why
On many developer machines, port `5432` may already be in use. This change allows contributors to specify a custom port without modifying shared files.

### Changes
- Updated `docker-compose.yml` to use `${POSTGRES_PORT:-5432}`
- Updated `.env.example` with `POSTGRES_PORT=5432`

Tested locally with `5434`, container is healthy and accessible.
