### PR TITLE
fix(ui): Prevent email overflow in user dropdown

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -214,10 +214,12 @@ export default function Dashboard() {
               </button>
 
             {showUserDropdown && (
-              <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-50">
+              <div className="absolute right-0 mt-2 w-64 bg-white rounded-md shadow-lg border border-gray-200 z-50">
                 <div className="py-1">
-                  <div className="px-4 py-2 text-sm text-gray-500 border-b">
-                    {user?.email}
+                  <div className="px-4 py-2 text-sm text-gray-500 border-b break-all overflow-hidden">
+                    <span className="block truncate" title={user?.email}>
+                      {user?.email}
+                    </span>
                   </div>
                   <Link
                     href="/settings"


### PR DESCRIPTION
 
 ### What is the issue 
 Addresses a UI bug where long email addresses in the user account dropdown menu would overflow their container, breaking the layout.

### Before 
<img width="354" height="199" alt="Screenshot 2025-07-30 at 9 29 49 AM" src="https://github.com/user-attachments/assets/b2b499c5-4f93-444f-ad91-c0f99f3385c3" />


### After 
<img width="317" height="226" alt="Screenshot 2025-07-30 at 9 30 13 AM" src="https://github.com/user-attachments/assets/628ad45e-8d06-4360-b406-d8b9059e04da" />
