### PR TITLE
fix(api): include _count.notes in board creation response

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -81,7 +81,12 @@ export async function POST(request: NextRequest) {
         description,
         organizationId: user.organization.id,
         createdBy: session.user.id
-      }
+      },
+      include: {
+        _count: {
+          select: { notes: true },
+        },
+      },
     })
 
     return NextResponse.json({ board }, { status: 201 })


### PR DESCRIPTION
Fixes #53 
Included notes in the prisma query to prevent client side exception on new board creation

## Screen Recording

https://github.com/user-attachments/assets/90f43ce7-bd52-4945-b0b9-08c1b6485553

