### PR TITLE
fix(api): Include _count.notes in board creation 

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -72,6 +72,23 @@ export async function POST(request: NextRequest) {
         description,
         organizationId: user.organization.id,
         createdBy: session.user.id
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        createdBy: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: {
+            notes: {
+              where: {
+                deletedAt: null
+              }
+            }
+          }
+        }
       }
     })
 


### PR DESCRIPTION
### What 

Addresses a runtime error where creating a new board  causes the Dashboard component to crash when trying to display the notes count.
 
 ### Why 

 POST `/api/boards` was returning boards without _count.notes , which was there in GET endpoint.
 
 ### Before 
 

https://github.com/user-attachments/assets/c1f716fe-07c6-4730-8185-b8a8a7496db3

### After 


https://github.com/user-attachments/assets/52a71350-b79b-4f0e-a97b-cd05f41ff92d


 
 