### PR TITLE
Fix : Navigation from boards/[id] back to Dashboard page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -115,20 +115,6 @@ export default function Dashboard() {
         const { boards } = await boardsResponse.json();
         setBoards(boards);
 
-        try {
-          const lastVisitedBoardId = localStorage.getItem("gumboard-last-visited-board");
-          if (lastVisitedBoardId) {
-            const boardExists = boards.some((board: Board) => board.id === lastVisitedBoardId);
-            if (boardExists) {
-              router.push(`/boards/${lastVisitedBoardId}`);
-              return;
-            } else {
-              localStorage.removeItem("gumboard-last-visited-board");
-            }
-          }
-        } catch (error) {
-          console.warn("Failed to check last visited board:", error);
-        }
       }
     } catch (error) {
       console.error("Error fetching data:", error);


### PR DESCRIPTION
Fixes issue #73 

Removed the logic that automatically redirects users to their last visited board stored in localStorage.
This feature was overriding user-initiated navigation back to the dashboard, causing confusion and creating a navigation loop from /boards/[id] back to itself .

