### PR TITLE
fix: Hero Section text alignment

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,8 +23,8 @@ export default async function HomePage() {
       <main className="flex-1">
         <section className="w-full py-12 md:py-15">
           <div className="container mx-auto px-4 md:px-6">
-            <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 xl:gap-24">
-              <div className="flex flex-col justify-center space-y-6">
+            <div className="grid gap-12 lg:grid-cols-2 lg:items-start lg:gap-16 xl:gap-24">
+              <div className="flex flex-col justify-center space-y-6 lg:mt-14">
                 <div className="flex items-center gap-3">
                   <StickyNote className="h-9 w-9 text-blue-600 dark:text-blue-400" />
                   <span className="text-4xl font-bold">Gumboard</span>

--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -290,7 +290,7 @@ export function StickyNotesDemo() {
       color: randomColor,
       tasks: [{ id: Date.now() + 1, text: "New to-do", completed: false }],
     }
-    setNotes([...notes, newNote])
+    setNotes([newNote, ...notes])
   }
 
   return (


### PR DESCRIPTION
Fixed Hero Section Text Alignement

- [x] Corrected Text Alignment
- [x] Now new notes come on top instead of last

Before

https://github.com/user-attachments/assets/2e1c21f3-d50a-4535-9da4-39ca31599291




After

https://github.com/user-attachments/assets/6567c911-707a-4c6c-bef8-d96f4b3f8044


