### PR TITLE
Allow google mail reuse

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -15,6 +15,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+          image: profile.picture,
+        }
+      },
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   pages: {


### PR DESCRIPTION
This PR fixes #95 

- Added allowDangerousEmailAccountLinking: true to the Google provider configuration
- Maintained test coverage for the account reuse scenario