### PR TITLE
Add missing step to install dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Keep on top of your team's to-dos.
 
 ### Install dependencies
 
+```bash
 npm install
+```
 
 ### Database Setup
 


### PR DESCRIPTION
This PR adds a missing step to the local setup instructions in the README file — specifically the npm install command to install project dependencies.

While it's a minor addition, not having this step explicitly mentioned could confuse beginners or first-time contributors who follow the README strictly. Adding this improves the developer experience and ensures a smoother setup process for everyone.