### PR TITLE
PR: Simplify Notes to Sticky Notes with Todos only (#123)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,5 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+// This is your Prisma schema file
+// learn more: https://pris.ly/d/prisma-schema
 
 generator client {
   provider = "prisma-client-js"
@@ -44,7 +41,6 @@ model Session {
   @@map("sessions")
 }
 
-// Updated User model for NextAuth compatibility
 model User {
   id             String       @id @default(cuid())
   name           String?
@@ -56,7 +52,7 @@ model User {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
   organizationId String?
-  isAdmin        Boolean      @default(false) // Admin role for organization
+  isAdmin        Boolean      @default(false)
   organization   Organization? @relation(fields: [organizationId], references: [id])
   invitedOrganizations OrganizationInvite[]
   createdSelfServeInvites OrganizationSelfServeInvite[]
@@ -96,22 +92,27 @@ model Board {
 }
 
 model Note {
-  id        String @id @default(cuid())
-  content   String @db.Text
-  color     String @default("#fef3c7") // Default yellow color
-  done      Boolean @default(false) // Track completion status
-  isChecklist Boolean @default(false) // Track if note is a checklist
-  checklistItems Json? // Store checklist items as JSON
-  slackMessageId String?
-  boardId   String
-  board     Board  @relation(fields: [boardId], references: [id], onDelete: Cascade)
-  createdBy String
-  user      User   @relation(fields: [createdBy], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  deletedAt DateTime? // Soft delete timestamp
+  id         String   @id @default(cuid())
+  title      String   @default("Untitled Note")
+  todos      Todo[]
+  boardId    String
+  board      Board    @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  createdBy  String
+  user       User     @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  deletedAt  DateTime?
 
   @@map("notes")
+}
+
+model Todo {
+  id        String   @id @default(cuid())
+  text      String
+  done      Boolean  @default(false)
+  noteId    String
+  note      Note     @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
 }
 
 model OrganizationInvite {
@@ -130,16 +131,16 @@ model OrganizationInvite {
 
 model OrganizationSelfServeInvite {
   id             String       @id @default(cuid())
-  token          String?      @unique // Cryptographically secure token for the URL
-  name           String       // Name/description for the invite link
+  token          String?      @unique
+  name           String
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   createdBy      String
   user           User         @relation(fields: [createdBy], references: [id])
   createdAt      DateTime     @default(now())
-  expiresAt      DateTime?    // Optional expiration date
-  usageLimit     Int?         // Optional usage limit
-  usageCount     Int          @default(0) // Track how many times it's been used
+  expiresAt      DateTime?
+  usageLimit     Int?
+  usageCount     Int          @default(0)
   isActive       Boolean      @default(true)
 
   @@map("organization_self_serve_invites")


### PR DESCRIPTION
# ✅ PR: Simplify Notes to Sticky Notes with Todos Only (#123)

## ✨ Summary

This PR simplifies the existing `Note` model into a **minimal Sticky Note** that only contains a list of **to-dos**, making the UX cleaner and more focused.

## 🎯 Changes Introduced

- 🔥 Removed unused fields from `Note`:
  - `content`
  - `done`
  - `isChecklist`
  - `checklistItems`
  - `color`
  - `slackMessageId`

- 🧩 Introduced new `Todo` model:
  ```prisma
  model Todo {
    id        String   @id @default(cuid())
    text      String
    done      Boolean  @default(false)
    noteId    String
    note      Note     @relation(fields: [noteId], references: [id], onDelete: Cascade)
    createdAt DateTime @default(now())
  }
  ```

- 🧼 Cleaned up and replaced `Note` model:
  ```prisma
  model Note {
    id         String   @id @default(cuid())
    title      String   @default("Untitled Note")
    todos      Todo[]
    boardId    String
    board      Board    @relation(fields: [boardId], references: [id], onDelete: Cascade)
    createdBy  String
    user       User     @relation(fields: [createdBy], references: [id], onDelete: Cascade)
    createdAt  DateTime @default(now())
    updatedAt  DateTime @updatedAt
    deletedAt  DateTime?
  }
  ```

- 📦 Migration applied: `simplify_note_model`
- 🔄 Existing Prisma relationships and cascade deletes are preserved.

## 🚀 How to Test

1. Run DB reset & migration:
    ```bash
    npx prisma migrate reset
    npx prisma generate
    ```

2. Start dev server:
    ```bash
    npm run dev
    ```

3. Test sticky note creation and adding to-dos via API or UI.

## 📌 Closes

- Closes #123
