### PR TITLE
fix: make OAuth buttons responsive with visible icons

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -220,19 +220,17 @@ function SignInContent() {
               </div>
             </div>
 
-            {/* OAuth Buttons */}
-            <div className="space-y-3 w-full mt-4">
+            <div className="flex flex-col lg:flex-row gap-3 w-full mt-4">
               {/* Google Button */}
               <Button
                 type="button"
                 variant="outline"
-                className="w-full h-12 justify-center dark:bg-zinc-950 dark:border-zinc-800 dark:text-zinc-100 cursor-pointer dark:hover:bg-zinc-900"
+                className="w-full lg:w-1/2 h-12 flex items-center justify-center dark:bg-zinc-950 dark:border-zinc-800 dark:text-zinc-100 cursor-pointer dark:hover:bg-zinc-900"
                 onClick={() => signIn("google", { callbackUrl: "/" })}
               >
                 <svg
                   className="w-5 h-5 mr-2"
                   viewBox="0 0 48 48"
-                  fill="none"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -259,15 +257,16 @@ function SignInContent() {
               <Button
                 type="button"
                 variant="outline"
-                className="w-full h-12 justify-center dark:bg-zinc-950 dark:border-zinc-800 dark:text-zinc-100 cursor-pointer dark:hover:bg-zinc-900"
+                className="w-full lg:w-1/2 h-12 flex items-center justify-center dark:bg-zinc-950 dark:border-zinc-800 dark:text-zinc-100 cursor-pointer dark:hover:bg-zinc-900"
                 onClick={() => signIn("github", { callbackUrl: "/" })}
               >
                 <svg
                   className="w-5 h-5 mr-2"
                   viewBox="0 0 24 24"
                   fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                  <path d="M12 0C5.373 0 0 5.373 0 12c0 5.303 3.438 9.8 8.207 11.387.6.111.793-.261.793-.577v-2.234C6.207 20.416 5.466 18.14 5.466 18.14c-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.806 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.009-.322 3.302 1.23.956-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.808 5.624-5.479 5.921.43.372.824 1.102.824 2.222v3.293c0 .319.193.694.801.576C20.565 21.796 24 17.299 24 12c0-6.627-5.373-12-12-12z" />
                 </svg>
                 Continue with GitHub
               </Button>


### PR DESCRIPTION
### What’s Changed

- Updated the layout of the Google and GitHub OAuth buttons.
- Buttons are now **side-by-side on large screens** (`lg:` breakpoint), and **stacked on small screens**.
- Fixed the SVGs so the icons now render properly.
- Improved styling for icon alignment with `flex items-center justify-center`.

### Preview

Responsive layout:
- ✅ Mobile: buttons stacked vertically
- ✅ Desktop: buttons side-by-side

SVG icons:
- ✅ Google icon (colored)
- ✅ GitHub icon (monochrome)

### Why

Improves login UX and visual clarity, especially on desktop.

---

✅ No backend logic changed.  
✅ Safe for merge.

### Before 
<img width="1920" height="1080" alt="Screenshot 2025-08-08 002810" src="https://github.com/user-attachments/assets/f8627f04-09db-40b1-9818-2d582d6c111c" />

### After 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b305b7b9-d5f6-4ac3-82bb-b5fb4f7a468c" />

