### PR TITLE
Component-ize UI of notecard and checklistItem

### DIFF
--- a/components/note/checklist-item.tsx
+++ b/components/note/checklist-item.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Trash2 } from "lucide-react"
+import type { ChecklistItemModel } from "@/lib/types/note"
+import { cn } from "@/lib/utils"
+
+export type ChecklistItemProps = {
+  item: ChecklistItemModel
+  onToggle: (itemId: string) => void
+  onChangeContent: (itemId: string, content: string) => void
+  onDelete: (itemId: string) => void
+}
+
+export function ChecklistItem({ item, onToggle, onChangeContent, onDelete }: ChecklistItemProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <Checkbox
+        id={`check-${item.id}`}
+        checked={item.checked}
+        onCheckedChange={() => onToggle(item.id)}
+        className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:border-zinc-600"
+      />
+      <Input
+        type="text"
+        value={item.content}
+        onChange={(e) => onChangeContent(item.id, e.target.value)}
+        className={cn(
+          "h-auto flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0",
+          item.checked && "text-slate-500 dark:text-zinc-500 line-through"
+        )}
+        style={{ overflow: "visible" }}
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6 opacity-50 hover:opacity-100 text-zinc-500 hover:text-red-600 dark:text-zinc-400 dark:hover:text-red-500"
+        onClick={() => onDelete(item.id)}
+      >
+        <Trash2 className="h-3 w-3" />
+        <span className="sr-only">Delete task</span>
+      </Button>
+    </div>
+  )
+}
+
+

--- a/components/note/note-card.tsx
+++ b/components/note/note-card.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import * as React from "react"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Plus, Trash2 } from "lucide-react"
+import { AnimatePresence, motion } from "framer-motion"
+import { ChecklistItem } from "./checklist-item"
+import type { ChecklistItemModel, NoteModel } from "@/lib/types/note"
+import { cn } from "@/lib/utils"
+
+export type NoteCardProps = {
+  note: NoteModel
+  onChange: (updated: NoteModel) => void
+  onDelete: (noteId: string) => void
+}
+
+const taskItemVariants = {
+  hidden: { opacity: 0, height: 0 },
+  visible: { opacity: 1, height: "auto", transition: { duration: 0.2 } },
+  exit: { opacity: 0, height: 0, transition: { duration: 0.15 } },
+}
+
+export function NoteCard({ note, onChange, onDelete }: NoteCardProps) {
+  const handleToggle = (itemId: string) => {
+    const updated = note.checklistItems.map((it) =>
+      it.id === itemId ? { ...it, checked: !it.checked } : it
+    )
+    onChange({ ...note, checklistItems: updated })
+  }
+
+  const handleContent = (itemId: string, content: string) => {
+    const updated = note.checklistItems.map((it) =>
+      it.id === itemId ? { ...it, content } as ChecklistItemModel : it
+    )
+    onChange({ ...note, checklistItems: updated })
+  }
+
+  const handleDeleteItem = (itemId: string) => {
+    const updated = note.checklistItems.filter((it) => it.id !== itemId)
+    onChange({ ...note, checklistItems: updated })
+  }
+
+  const handleAddItem = () => {
+    const nowId = String(Date.now())
+    const newItem: ChecklistItemModel = {
+      id: nowId,
+      content: "New task",
+      checked: false,
+      order: (note.checklistItems?.length ?? 0) + 1,
+    }
+    onChange({ ...note, checklistItems: [...(note.checklistItems ?? []), newItem] })
+  }
+
+  const authorInitial = note.author.initial ?? note.author.name?.[0] ?? "?"
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-xl p-4 transition-all",
+        "bg-white dark:bg-zinc-900",
+        note.color
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Avatar className="h-8 w-8 border-2 border-white dark:border-zinc-800">
+            <AvatarFallback className="bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200">
+              {authorInitial}
+            </AvatarFallback>
+          </Avatar>
+          <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+            {note.author.name}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-zinc-500 hover:text-red-600 dark:text-zinc-400 dark:hover:text-red-500"
+          onClick={() => onDelete(note.id)}
+        >
+          <Trash2 className="h-4 w-4" />
+          <span className="sr-only">Delete note</span>
+        </Button>
+      </div>
+      <div className="flex flex-col gap-2">
+        <AnimatePresence>
+          {note.checklistItems.map((it) => (
+            <motion.div
+              key={it.id}
+              className="flex items-center gap-3"
+              variants={taskItemVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              layout
+            >
+              <ChecklistItem
+                item={it}
+                onToggle={handleToggle}
+                onChangeContent={handleContent}
+                onDelete={handleDeleteItem}
+              />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleAddItem}
+        className="mt-1 justify-start text-slate-600 dark:text-zinc-300 hover:text-slate-900 dark:hover:text-zinc-100"
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Add task
+      </Button>
+    </div>
+  )
+}
+
+

--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -3,47 +3,48 @@
 import * as React from "react"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { StickyNoteCard, type Note } from "@/components/sticky-note-card"
+import { NoteCard } from "@/components/note/note-card"
+import type { NoteModel, ChecklistItemModel } from "@/lib/types/note"
 import { Plus } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 
-const initialNotes: Note[] = [
+const initialNotes: NoteModel[] = [
   {
-    id: 1,
+    id: "1",
     author: { name: "Sahil", initial: "S" },
     color: "bg-green-200/70",
-    tasks: [
-      { id: 101, text: "Gumboard release by Friday", completed: false },
-      { id: 102, text: "Finance update by Friday", completed: false },
-      { id: 103, text: "Jacquez", completed: true },
+    checklistItems: [
+      { id: "101", content: "Gumboard release by Friday", checked: false, order: 1 },
+      { id: "102", content: "Finance update by Friday", checked: false, order: 2 },
+      { id: "103", content: "Jacquez", checked: true, order: 3 },
     ],
   },
   {
-    id: 2,
+    id: "2",
     author: { name: "Michelle", initial: "M" },
     color: "bg-purple-200/60",
-    tasks: [
-      { id: 201, text: "Helper Tix (Mon-Fri)", completed: false },
-      { id: 202, text: "Active Refunds (2x a week)", completed: false },
-      { id: 203, text: "Card Tester Metabase (DAILY)", completed: true },
+    checklistItems: [
+      { id: "201", content: "Helper Tix (Mon-Fri)", checked: false, order: 1 },
+      { id: "202", content: "Active Refunds (2x a week)", checked: false, order: 2 },
+      { id: "203", content: "Card Tester Metabase (DAILY)", checked: true, order: 3 },
     ],
   },
   {
-    id: 3,
+    id: "3",
     author: { name: "Steve", initial: "S" },
     color: "bg-blue-200/60",
-    tasks: [
-      { id: 301, text: "Review support huddle", completed: false },
-      { id: 302, text: "Metabase queries", completed: false },
+    checklistItems: [
+      { id: "301", content: "Review support huddle", checked: false, order: 1 },
+      { id: "302", content: "Metabase queries", checked: false, order: 2 },
     ],
   },
   {
-    id: 4,
+    id: "4",
     author: { name: "Daniel", initial: "D" },
     color: "bg-pink-200/70",
-    tasks: [
-      { id: 401, text: "Fixed unnecessary description", completed: false },
-      { id: 402, text: "PR reviews", completed: true },
+    checklistItems: [
+      { id: "401", content: "Fixed unnecessary description", checked: false, order: 1 },
+      { id: "402", content: "PR reviews", checked: true, order: 2 },
     ],
   },
 ]
@@ -271,24 +272,24 @@ const itemVariants = {
 }
 
 export function StickyNotesDemo() {
-  const [notes, setNotes] = useState<Note[]>(initialNotes)
+  const [notes, setNotes] = useState<NoteModel[]>(initialNotes)
 
-  const handleUpdateNote = (updatedNote: Note) => {
+  const handleUpdateNote = (updatedNote: NoteModel) => {
     setNotes(notes.map((note) => (note.id === updatedNote.id ? updatedNote : note)))
   }
 
-  const handleDeleteNote = (noteId: number) => {
+  const handleDeleteNote = (noteId: string) => {
     setNotes(notes.filter((note) => note.id !== noteId))
   }
 
   const handleAddNote = () => {
     const randomColor = noteColors[Math.floor(Math.random() * noteColors.length)]
     const randomAuthor = authors[Math.floor(Math.random() * authors.length)]
-    const newNote: Note = {
-      id: Date.now(),
+    const newNote: NoteModel = {
+      id: String(Date.now()),
       author: randomAuthor,
       color: randomColor,
-      tasks: [{ id: Date.now() + 1, text: "New to-do", completed: false }],
+      checklistItems: [{ id: String(Date.now() + 1), content: "New to-do", checked: false, order: 1 } as ChecklistItemModel],
     }
     setNotes([newNote, ...notes])
   }
@@ -311,7 +312,7 @@ export function StickyNotesDemo() {
           <AnimatePresence>
             {notes.map((note) => (
               <motion.div key={note.id} className="mb-4 break-inside-avoid" variants={itemVariants} exit="exit" layout>
-                <StickyNoteCard note={note} onUpdate={handleUpdateNote} onDelete={handleDeleteNote} />
+                <NoteCard note={note} onChange={handleUpdateNote} onDelete={handleDeleteNote} />
               </motion.div>
             ))}
           </AnimatePresence>

--- a/lib/client/note-service.ts
+++ b/lib/client/note-service.ts
@@ -1,0 +1,79 @@
+"use client"
+
+import type { ChecklistItemModel, NoteModel, NoteUpdate } from "@/lib/types/note"
+
+export type ApiNote = {
+  id: string
+  content: string
+  color: string
+  done: boolean
+  checklistItems?: ChecklistItemModel[] | null
+  user: { id: string; name: string | null; email: string }
+  board?: { id: string; name: string }
+}
+
+function mapApiNoteToModel(n: ApiNote): NoteModel {
+  return {
+    id: n.id,
+    author: {
+      id: n.user.id,
+      name: n.user.name || n.user.email,
+      email: n.user.email,
+      initial: (n.user.name || n.user.email)[0]?.toUpperCase(),
+    },
+    color: n.color,
+    checklistItems: (n.checklistItems ?? []).map((it, idx) => ({
+      id: it.id,
+      content: it.content,
+      checked: it.checked,
+      order: it.order ?? idx + 1,
+    })),
+    done: n.done,
+  }
+}
+
+export async function fetchBoardNotes(boardId: string): Promise<NoteModel[]> {
+  const res = await fetch(`/api/boards/${boardId}/notes`, { cache: "no-store" })
+  if (!res.ok) throw new Error("Failed to fetch notes")
+  const data = await res.json()
+  const notes: ApiNote[] = data.notes
+  return notes.map(mapApiNoteToModel)
+}
+
+export async function fetchAllOrgNotes(): Promise<NoteModel[]> {
+  const res = await fetch(`/api/boards/all-notes/notes`, { cache: "no-store" })
+  if (!res.ok) throw new Error("Failed to fetch notes")
+  const data = await res.json()
+  const notes: ApiNote[] = data.notes
+  return notes.map(mapApiNoteToModel)
+}
+
+export async function createNote(boardId: string, checklistItems: ChecklistItemModel[] = []): Promise<NoteModel> {
+  const body = { content: "", checklistItems }
+  const res = await fetch(`/api/boards/${boardId}/notes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error("Failed to create note")
+  const { note } = await res.json()
+  return mapApiNoteToModel(note)
+}
+
+export async function updateNote(boardId: string, noteId: string, update: NoteUpdate & { content?: string }): Promise<NoteModel> {
+  const res = await fetch(`/api/boards/${boardId}/notes/${noteId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(update),
+  })
+  if (!res.ok) throw new Error("Failed to update note")
+  const { note } = await res.json()
+  return mapApiNoteToModel(note)
+}
+
+export async function deleteNote(boardId: string, noteId: string): Promise<void> {
+  const res = await fetch(`/api/boards/${boardId}/notes/${noteId}`, { method: "DELETE" })
+  if (!res.ok) throw new Error("Failed to delete note")
+}
+
+

--- a/lib/types/note.ts
+++ b/lib/types/note.ts
@@ -1,0 +1,27 @@
+export type ChecklistItemModel = {
+  id: string
+  content: string
+  checked: boolean
+  order: number
+}
+
+export type NoteAuthor = {
+  id?: string
+  name: string
+  email?: string
+  initial?: string
+}
+
+export type NoteModel = {
+  id: string
+  author: NoteAuthor
+  color: string
+  checklistItems: ChecklistItemModel[]
+  done?: boolean
+}
+
+export type NoteUpdate = Partial<Pick<NoteModel, "color" | "done">> & {
+  checklistItems?: ChecklistItemModel[]
+}
+
+


### PR DESCRIPTION
Fixes: #128 
<pre>
Added modular UI: NoteCard and ChecklistItem in components/note/.
Introduced shared types: NoteModel/ChecklistItemModel in lib/types/note.ts.
Added client service: lib/client/note-service.ts (fetch/create/update/delete notes, API → model mapping).
Refactored homepage demo to use new Note + ChecklistItems (components/sticky-notes-demo.tsx).
</pre>