### PR TITLE
fix: remove validation check on content to prevent error on note creation in all-notes page

### DIFF
--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -66,9 +66,9 @@ export async function POST(request: NextRequest) {
     }
 
     const { content, color, boardId } = await request.json()
-
-    if (!content || !boardId) {
-      return NextResponse.json({ error: "Content and board ID are required" }, { status: 400 })
+    
+    if (!boardId) {
+      return NextResponse.json({ error: "Board ID is required" }, { status: 400 })
     }
 
     // Verify user has access to the specified board (same organization)


### PR DESCRIPTION
Fixes #159 

Removed validation check for content parameter in backend to prevent error on creating new note when all-notes is selected 

https://github.com/user-attachments/assets/2ae593e4-d45e-40ac-bca8-2a2025d24539

