### PR TITLE
Normalize checklist items into relational table + Slack dedup for todos

### DIFF
--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -17,7 +17,7 @@ function sanitizeIncomingItems(items: any[]): ChecklistItemDTO[] {
     .filter((i) => i && typeof i.content === 'string')
     .map((i, idx) => ({
       id: typeof i.id === 'string' ? i.id : '',
-      content: String(i.content),
+      content: String(i.content), 
       checked: Boolean(i?.checked),
       order: Number.isFinite(i?.order) ? Number(i.order) : idx,
     }))

--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -2,32 +2,25 @@ import { NextRequest, NextResponse } from "next/server"
 import { auth } from "@/auth"
 import { db } from "@/lib/db"
 import { updateSlackMessage, formatNoteForSlack, sendSlackMessage, sendTodoNotification, hasValidContent, shouldSendNotification } from "@/lib/slack"
-import type { ChecklistItem } from "@/components/checklist-item"
 
-// Helper function to detect checklist item changes
-function detectChecklistChanges(oldItems: ChecklistItem[] = [], newItems: ChecklistItem[] = []) {
-  const addedItems: ChecklistItem[] = []
-  const completedItems: ChecklistItem[] = []
-  
-  // Create map for efficient lookup
-  const oldItemsMap = new Map(oldItems.map(item => [item.id, item]))
-  
-  // Find newly added items
-  for (const newItem of newItems) {
-    if (!oldItemsMap.has(newItem.id)) {
-      addedItems.push(newItem)
-    }
-  }
-  
-  // Find newly completed items
-  for (const newItem of newItems) {
-    const oldItem = oldItemsMap.get(newItem.id)
-    if (oldItem && !oldItem.checked && newItem.checked) {
-      completedItems.push(newItem)
-    }
-  }
-  
-  return { addedItems, completedItems }
+interface ChecklistItemDTO {
+  id: string
+  content: string
+  checked: boolean
+  order: number
+}
+
+// Normalize incoming items
+function sanitizeIncomingItems(items: any[]): ChecklistItemDTO[] {
+  if (!Array.isArray(items)) return []
+  return items
+    .filter((i) => i && typeof i.content === 'string')
+    .map((i, idx) => ({
+      id: typeof i.id === 'string' ? i.id : '',
+      content: String(i.content),
+      checked: Boolean(i?.checked),
+      order: Number.isFinite(i?.order) ? Number(i.order) : idx,
+    }))
 }
 
 // Update a note
@@ -95,63 +88,143 @@ export async function PUT(
       return NextResponse.json({ error: "Only the note author or admin can edit this note" }, { status: 403 })
     }
 
-    const updatedNote = await db.note.update({
-      where: { id: noteId },
-      data: {
-        ...(content !== undefined && { content }),
-        ...(color !== undefined && { color }),
-        ...(done !== undefined && { done }),
-        ...(checklistItems !== undefined && { checklistItems }),
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true
-          }
+    // Prepare to update note fields, then reconcile checklist items relationally in a transaction
+    const sanitizedIncoming = Array.isArray(checklistItems) ? sanitizeIncomingItems(checklistItems) : undefined
+
+    const result = await db.$transaction(async (tx) => {
+      // Update note core fields first
+      const updated = await tx.note.update({
+        where: { id: noteId },
+        data: {
+          ...(content !== undefined && { content }),
+          ...(color !== undefined && { color }),
+          ...(done !== undefined && { done }),
         },
-        board: {
-          select: {
-            name: true,
-            sendSlackUpdates: true
+        include: {
+          user: {
+            select: { id: true, name: true, email: true }
+          },
+          board: { select: { name: true, sendSlackUpdates: true } },
+        }
+      })
+
+      // If no checklist updates provided, return early
+      if (!sanitizedIncoming) {
+        return { updated, itemChanges: null }
+      }
+
+      // Fetch existing items
+      const existingItems = await tx.checklistItem.findMany({
+        where: { noteId },
+        orderBy: { order: 'asc' }
+      })
+
+      const existingById = new Map(existingItems.map((i) => [i.id, i]))
+
+      const changes = {
+        created: [] as typeof existingItems,
+        toggledCompleted: [] as Array<{ prev: boolean; item: typeof existingItems[number] }>,
+        updatedTextOnly: [] as typeof existingItems,
+        deleted: [] as typeof existingItems,
+      }
+
+      // Upsert or create
+      for (const incoming of sanitizedIncoming) {
+        if (incoming.id && existingById.has(incoming.id)) {
+          const prev = existingById.get(incoming.id)!
+          const didToggle = prev.checked !== incoming.checked
+          const didTextChange = prev.content !== incoming.content
+
+          const updatedItem = await tx.checklistItem.update({
+            where: { id: prev.id },
+            data: {
+              content: incoming.content,
+              checked: incoming.checked,
+              order: incoming.order,
+            }
+          })
+
+          if (didToggle) {
+            changes.toggledCompleted.push({ prev: prev.checked, item: updatedItem })
+          } else if (didTextChange) {
+            changes.updatedTextOnly.push(updatedItem)
           }
+
+          existingById.delete(incoming.id)
+        } else {
+          // Create new item
+          const created = await tx.checklistItem.create({
+            data: {
+              content: incoming.content,
+              checked: incoming.checked,
+              order: incoming.order,
+              noteId,
+            }
+          })
+          changes.created.push(created)
         }
       }
+
+      // Remaining existingById are deleted
+      if (existingById.size > 0) {
+        const toDelete = Array.from(existingById.values())
+        changes.deleted = toDelete
+        // Soft-delete is not defined for items; perform hard delete
+        await tx.checklistItem.deleteMany({ where: { id: { in: toDelete.map((i) => i.id) } } })
+      }
+
+      return { updated, itemChanges: changes }
     })
 
-    // Send individual todo notifications if checklist items have changed
-    if (checklistItems !== undefined && user.organization?.slackWebhookUrl) {
-      const oldItems = (note.checklistItems as unknown as ChecklistItem[]) || []
-      const newItems = (checklistItems as unknown as ChecklistItem[]) || []
-      const { addedItems, completedItems } = detectChecklistChanges(oldItems, newItems)
-      
+    const updatedNote = result.updated
+
+    // Slack notifications for checklist changes: only on create and toggle
+    if (result.itemChanges && user.organization?.slackWebhookUrl && updatedNote.board.sendSlackUpdates) {
+      const { created, toggledCompleted } = result.itemChanges
       const userName = user.name || user.email || 'Unknown User'
       const boardName = updatedNote.board.name
-      
-      // Send notifications for newly added todos
-      for (const addedItem of addedItems) {
-        if (hasValidContent(addedItem.content) && shouldSendNotification(session.user.id, boardId, boardName, updatedNote.board.sendSlackUpdates)) {
-          await sendTodoNotification(
-            user.organization.slackWebhookUrl,
-            addedItem.content,
-            boardName,
-            userName,
-            'added'
-          )
+
+      // New items -> 'added' and store message ID for dedup
+      for (const item of created) {
+        if (!hasValidContent(item.content)) continue
+        if (!shouldSendNotification(session.user.id, boardId, boardName, updatedNote.board.sendSlackUpdates)) continue
+        const msgId = await sendTodoNotification(
+          user.organization.slackWebhookUrl,
+          item.content,
+          boardName,
+          userName,
+          'added'
+        )
+        if (msgId) {
+          await db.checklistItem.update({ where: { id: item.id }, data: { slackMessageId: msgId } })
         }
       }
-      
-      // Send notifications for newly completed todos
-      for (const completedItem of completedItems) {
-        if (shouldSendNotification(session.user.id, boardId, boardName, updatedNote.board.sendSlackUpdates)) {
-          await sendTodoNotification(
+
+      // Toggled completed -> 'completed' or 'reopened'
+      for (const { prev, item } of toggledCompleted) {
+        if (!hasValidContent(item.content)) continue
+        if (!shouldSendNotification(session.user.id, boardId, boardName, updatedNote.board.sendSlackUpdates)) continue
+        if (item.slackMessageId) {
+          // Update existing Slack message to avoid duplication
+          await updateSlackMessage(
             user.organization.slackWebhookUrl,
-            completedItem.content,
+            item.content,
+            item.checked,
+            boardName,
+            userName
+          )
+        } else {
+          const action = item.checked ? 'completed' : 'reopened'
+          const msgId = await sendTodoNotification(
+            user.organization.slackWebhookUrl,
+            item.content,
             boardName,
             userName,
-            'completed'
+            action
           )
+          if (msgId) {
+            await db.checklistItem.update({ where: { id: item.id }, data: { slackMessageId: msgId } })
+          }
         }
       }
     }
@@ -178,14 +251,27 @@ export async function PUT(
       }
     }
 
-    // Update existing Slack message when done status changes
+    // Update existing Slack message when note.done status changes (legacy note-level message)
     if (done !== undefined && user.organization?.slackWebhookUrl && note.slackMessageId) {
       const userName = note.user?.name || note.user?.email || 'Unknown User'
       const boardName = note.board.name
       await updateSlackMessage(user.organization.slackWebhookUrl, note.content, done, boardName, userName)
     }
 
-    return NextResponse.json({ note: updatedNote })
+    // Return full note with checklist items
+    const fullNote = await db.note.findUnique({
+      where: { id: noteId },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+        board: { select: { name: true, sendSlackUpdates: true } },
+        checklistItems: {
+          orderBy: { order: 'asc' },
+          select: { id: true, content: true, checked: true, order: true }
+        }
+      }
+    })
+
+    return NextResponse.json({ note: fullNote })
   } catch (error) {
     console.error("Error updating note:", error)
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })

--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -15,7 +15,7 @@ export async function GET(
 
     const board = await db.board.findUnique({
       where: { id: boardId },
-      include: { 
+      include: {
         notes: {
           where: {
             deletedAt: null // Only include non-deleted notes
@@ -27,6 +27,10 @@ export async function GET(
                 name: true,
                 email: true
               }
+            },
+            checklistItems: {
+              orderBy: { order: 'asc' },
+              select: { id: true, content: true, checked: true, order: true }
             }
           }
         }
@@ -109,13 +113,14 @@ export async function POST(
 
     const randomColor = color || NOTE_COLORS[Math.floor(Math.random() * NOTE_COLORS.length)]
 
+    // Create note first
     const note = await db.note.create({
       data: {
         content,
         color: randomColor,
         boardId,
         createdBy: session.user.id,
-        ...(checklistItems !== undefined && { checklistItems }),
+        isChecklist: Array.isArray(checklistItems) && checklistItems.length > 0,
       },
       include: {
         user: {
@@ -124,9 +129,41 @@ export async function POST(
             name: true,
             email: true
           }
+        },
+        checklistItems: {
+          orderBy: { order: 'asc' },
+          select: { id: true, content: true, checked: true, order: true }
         }
       }
     })
+
+    // If checklist items provided, create them relationally
+    let createdItems: Array<{ id: string; content: string; checked: boolean; order: number }> = []
+    if (Array.isArray(checklistItems) && checklistItems.length > 0) {
+      const sanitized = checklistItems
+        .filter((i: any) => typeof i?.content === 'string')
+        .map((i: any, idx: number) => ({
+          content: String(i.content),
+          checked: Boolean(i?.checked),
+          order: Number.isFinite(i?.order) ? Number(i.order) : idx,
+        }))
+
+      if (sanitized.length > 0) {
+        // Create items individually to capture IDs
+        createdItems = []
+        for (const [idx, item] of sanitized.entries()) {
+          const created = await db.checklistItem.create({
+            data: {
+              content: item.content,
+              checked: item.checked,
+              order: item.order ?? idx,
+              noteId: note.id,
+            }
+          })
+          createdItems.push({ id: created.id, content: created.content, checked: created.checked, order: created.order })
+        }
+      }
+    }
 
     if (user.organization?.slackWebhookUrl && hasValidContent(content) && shouldSendNotification(session.user.id, boardId, board.name, board.sendSlackUpdates)) {
       const slackMessage = formatNoteForSlack(note, board.name, user.name || user.email)
@@ -144,7 +181,41 @@ export async function POST(
       }
     }
 
-    return NextResponse.json({ note }, { status: 201 })
+    // Optionally send Slack notifications for created checklist items (creation only)
+    // We intentionally avoid shouldSendNotification per-item to reduce debounce collisions across bulk adds
+    if (createdItems.length > 0 && user.organization?.slackWebhookUrl && board.sendSlackUpdates) {
+      const userName = user.name || user.email
+      for (const item of createdItems) {
+        if (!hasValidContent(item.content)) continue
+        const msgId = await sendSlackMessage(user.organization.slackWebhookUrl, {
+          text: `:heavy_plus_sign: ${item.content} by ${userName} in ${board.name}`,
+          username: 'Gumboard',
+          icon_emoji: ':clipboard:'
+        })
+        if (msgId) {
+          await db.checklistItem.update({
+            where: { id: item.id },
+            data: { slackMessageId: msgId }
+          })
+        }
+      }
+    }
+
+    // Return note with checklist items
+    const fullNote = await db.note.findUnique({
+      where: { id: note.id },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true }
+        },
+        checklistItems: {
+          orderBy: { order: 'asc' },
+          select: { id: true, content: true, checked: true, order: true }
+        }
+      }
+    })
+
+    return NextResponse.json({ note: fullNote }, { status: 201 })
   } catch (error) {
     console.error("Error creating note:", error)
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })

--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -43,6 +43,10 @@ export async function GET(request: NextRequest) {
             id: true,
             name: true
           }
+        },
+        checklistItems: {
+          orderBy: { order: 'asc' },
+          select: { id: true, content: true, checked: true, order: true }
         }
       },
       orderBy: {

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -104,14 +104,28 @@ export function formatNoteForSlack(note: { content: string }, boardName: string,
   return `:heavy_plus_sign: ${note.content} by ${userName} in ${boardName}`
 }
 
-export function formatTodoForSlack(todoContent: string, boardName: string, userName: string, action: 'added' | 'completed'): string {
+export function formatTodoForSlack(
+  todoContent: string,
+  boardName: string,
+  userName: string,
+  action: 'added' | 'completed' | 'reopened'
+): string {
   if (action === 'completed') {
     return `:white_check_mark: ${todoContent} by ${userName} in ${boardName}`
+  }
+  if (action === 'reopened') {
+    return `:arrows_counterclockwise: ${todoContent} by ${userName} in ${boardName}`
   }
   return `:heavy_plus_sign: ${todoContent} by ${userName} in ${boardName}`
 }
 
-export async function sendTodoNotification(webhookUrl: string, todoContent: string, boardName: string, userName: string, action: 'added' | 'completed'): Promise<string | null> {
+export async function sendTodoNotification(
+  webhookUrl: string,
+  todoContent: string,
+  boardName: string,
+  userName: string,
+  action: 'added' | 'completed' | 'reopened'
+): Promise<string | null> {
   const message = formatTodoForSlack(todoContent, boardName, userName, action)
   return await sendSlackMessage(webhookUrl, {
     text: message,

--- a/prisma/migrations/20250808071400_create_checklist_items_table/migration.sql
+++ b/prisma/migrations/20250808071400_create_checklist_items_table/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `checklistItems` on the `notes` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "notes" DROP COLUMN "checklistItems",
+ADD COLUMN     "isChecklist" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "checklist_items" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "checked" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "noteId" TEXT NOT NULL,
+    "slackMessageId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "checklist_items_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "checklist_items" ADD CONSTRAINT "checklist_items_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "notes"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250808192721_remove_is_checklist_field/migration.sql
+++ b/prisma/migrations/20250808192721_remove_is_checklist_field/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isChecklist` on the `notes` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "notes" DROP COLUMN "isChecklist";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,17 +100,32 @@ model Note {
   content   String @db.Text
   color     String @default("#fef3c7") // Default yellow color
   done      Boolean @default(false) // Track completion status
-  checklistItems Json? // Store checklist items as JSON
-  slackMessageId String?
+  isChecklist Boolean @default(false) // Track if note is a checklist
+  slackMessageId String? // Slack message ID for updates
   boardId   String
   board     Board  @relation(fields: [boardId], references: [id], onDelete: Cascade)
   createdBy String
   user      User   @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+  checklistItems ChecklistItem[] // Reference to checklist items table
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   deletedAt DateTime? // Soft delete timestamp
 
   @@map("notes")
+}
+
+model ChecklistItem {
+  id        String @id @default(cuid())
+  content   String @db.Text
+  checked   Boolean @default(false)
+  order     Int @default(0)
+  noteId    String
+  slackMessageId String? // Slack message ID for individual item updates
+  note      Note @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("checklist_items")
 }
 
 model OrganizationInvite {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,6 @@ model Note {
   content   String @db.Text
   color     String @default("#fef3c7") // Default yellow color
   done      Boolean @default(false) // Track completion status
-  isChecklist Boolean @default(false) // Track if note is a checklist
   slackMessageId String? // Slack message ID for updates
   boardId   String
   board     Board  @relation(fields: [boardId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
### Summary
- PR for issue #124 
- Move checklist items from JSON on `notes` to first-class rows in `checklist_items`.
- Add Slack notification deduplication: create once, update on toggle, ignore text edits/reorders/deletes.
- Update API routes to read/write relational items using transactions and return normalized data.
- Keep UI/UX unchanged; frontend consumes the same shape, now populated from the relational table.


### What Changed

- API
  - `app/api/boards/[id]/notes/route.ts`
    - GET: returns notes with `checklistItems` (ordered) included.
    - POST: creates note, then relational checklist items; returns note with items.
    - Sends Slack message for the note only if content is meaningful.
    - Sends Slack messages for new checklist items and stores `slackMessageId` per item.
  - `app/api/boards/[id]/notes/[noteId]/route.ts`
    - PUT: wraps updates in a DB transaction, reconciles checklist items (upsert/delete by id, reorder), and returns full note with ordered items.
    - Slack notifications:
      - New items: send “added” once and store the returned `slackMessageId`.
      - Toggle complete: if we have a `slackMessageId`, “update” (post deduped update); otherwise send once and backfill the id.
      - Text edits, reorders, and deletions: no Slack messages.
      - Note-level `done`: legacy message behavior preserved.
  - `app/api/boards/all-notes/notes/route.ts`
    - GET: includes relational `checklistItems` (ordered).

- Slack helper (`lib/slack.ts`)
  - Added `'reopened'` action for undoing completed items.
  - Kept note-level formatting helpers and debounce logic (`shouldSendNotification`).
  - Per-item operations now store `slackMessageId` to avoid duplicates.

### Approach
- Normalize data at the DB level to track each checklist item independently.
- Use DB transactions for item reconciliation:
  - Incoming items are sanitized and diffed against existing items by id.
  - Upsert content/checked/order; hard-delete removed items.
- Dedup Slack:
  - On create: send once and store `slackMessageId`.
  - On toggle: update existing message if we have a stored id; otherwise send once and backfill.
  - Ignore non-meaningful changes.
- Preserve API response shapes; include ordered `checklistItems` on reads.

### Testing Done
- Verified:
  - Note create with/without checklist items.
  - Add item, toggle, text edit, reorder, delete.
  - Slack: only “added”, “completed”, “reopened” fire; edits/reorders/deletes do not.
  - All notes and per-board views return items ordered by `order`.