### PR TITLE
Fix long checklist item overflow issue #176

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+
+# vscode
+.vscode

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -242,7 +242,7 @@ export default function BoardPage({
         addingItemHeight;
       const totalChecklistHeight = Math.max(minContentHeight, checklistHeight);
 
-      return headerHeight + paddingHeight + totalChecklistHeight + addTaskButtonHeight;
+      return headerHeight + paddingHeight + totalChecklistHeight + 40; // Extra space for + button
     } else {
       // Original logic for regular notes
       const lines = note.content.split("\n");
@@ -1203,6 +1203,8 @@ export default function BoardPage({
                 top: note.y,
                 width: note.width,
                 height: note.height,
+                wordWrap: "break-word",
+                whiteSpace: "normal",
                 padding: `${getResponsiveConfig().notePadding}px`,
                 backgroundColor:
                   resolvedTheme === "dark" ? "#18181B" : note.color,

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { ChecklistItem as ChecklistItemComponent, ChecklistItem } from "@/components/checklist-item";
 import { cn } from "@/lib/utils";
 import { Trash2, Plus, Archive } from "lucide-react";
-import { useTheme } from "next-themes";
+import { useLayoutEffect, useCallback, useRef } from "react";
 
 // Core domain types
 export interface User {
@@ -57,6 +57,11 @@ interface NoteProps {
   onUpdate?: (note: Note) => void;
   onDelete?: (noteId: string) => void;
   onArchive?: (noteId: string) => void;
+  onAddChecklistItem?: (noteId: string, content: string) => void;
+  onToggleChecklistItem?: (noteId: string, itemId: string) => void;
+  onEditChecklistItem?: (noteId: string, itemId: string, content: string) => void;
+  onDeleteChecklistItem?: (noteId: string, itemId: string) => void;
+  onSplitChecklistItem?: (noteId: string, itemId: string, content: string, cursorPosition: number) => void;
   readonly?: boolean;
   showBoardName?: boolean;
   className?: string;
@@ -70,6 +75,11 @@ export function Note({
   onUpdate,
   onDelete,
   onArchive,
+  onAddChecklistItem,
+  onToggleChecklistItem,
+  onEditChecklistItem,
+  onDeleteChecklistItem,
+  onSplitChecklistItem,
   readonly = false,
   showBoardName = false,
   className,
@@ -80,6 +90,7 @@ export function Note({
   const [editContent, setEditContent] = useState(note.content);
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [editingItemContent, setEditingItemContent] = useState("");
+  const contentRef = useRef<HTMLDivElement>(null);
   const [addingItem, setAddingItem] = useState(
     !readonly &&
     currentUser &&
@@ -87,7 +98,6 @@ export function Note({
     (!note.checklistItems || note.checklistItems.length === 0)
   );
   const [newItemContent, setNewItemContent] = useState("");
-  const newItemInputRef = useRef<HTMLInputElement>(null);
 
   const canEdit = !readonly && (currentUser?.id === note.user.id || currentUser?.isAdmin);
 
@@ -468,8 +478,8 @@ export function Note({
           />
         </div>
       ) : (
-        <div className="flex flex-col">
-          <div className="overflow-y-auto space-y-1">
+        <div className="flex-1 flex flex-col">
+          <div className="overflow-y-auto space-y-1 flex-1">
             {/* Checklist Items */}
             {note.checklistItems?.map((item) => (
               <ChecklistItemComponent


### PR DESCRIPTION
## What does this PR do?

Fixes the UI issue where long checklist items overflow their container in notes.

## Related Issue  
Closes #176

## How did you fix it?

- Updated styles/layout in `app/boards/[id]/page.tsx` to handle long text properly.
- Ensured checklist items wrap or resize instead of overflowing.

## Screenshots

### Before

<img width="754" height="1666" alt="Screenshot 2025-08-09 at 8 02 08 AM" src="https://github.com/user-attachments/assets/af3cfcc2-ab3a-435a-8102-5b16cee7769d" />

### After


https://github.com/user-attachments/assets/05bd8b3a-ccb9-4fe1-b972-8d7e90483076


