### PR TITLE
fix: make empty state visible without scrolling by overlaying it in board area

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1548,13 +1548,13 @@ export default function BoardPage({
         ref={boardRef}
         className="relative w-full bg-gray-50 dark:bg-zinc-950"
         style={{
-          height: boardHeight,
+          height: notes.length > 0 ? boardHeight : undefined,
           minHeight: "calc(100vh - 64px)", // Account for header height
         }}
       >
 
         {/* Notes */}
-        <div className="relative w-full h-full">
+        <div className="absolute inset-0">
           {layoutNotes.map((note) => (
             <NoteCard
               key={note.id}
@@ -1590,7 +1590,7 @@ export default function BoardPage({
             dateRange.startDate ||
             dateRange.endDate ||
             selectedAuthor) && (
-            <div className="flex flex-col items-center justify-center h-96 text-gray-500 dark:text-gray-400">
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center px-4 text-center text-gray-500 dark:text-gray-400">
               <Search className="w-12 h-12 mb-4 text-gray-400 dark:text-gray-500" />
               <div className="text-xl mb-2">No notes found</div>
               <div className="text-sm mb-4 text-center">

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1548,13 +1548,13 @@ export default function BoardPage({
         ref={boardRef}
         className="relative w-full bg-gray-50 dark:bg-zinc-950"
         style={{
-          height: notes.length > 0 ? boardHeight : undefined,
+          height: boardHeight,
           minHeight: "calc(100vh - 64px)", // Account for header height
         }}
       >
 
         {/* Notes */}
-        <div className="absolute inset-0">
+        <div className="relative w-full h-full">
           {layoutNotes.map((note) => (
             <NoteCard
               key={note.id}
@@ -1590,7 +1590,7 @@ export default function BoardPage({
             dateRange.startDate ||
             dateRange.endDate ||
             selectedAuthor) && (
-            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center px-4 text-center text-gray-500 dark:text-gray-400">
+            <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center text-gray-500 dark:text-gray-400">
               <Search className="w-12 h-12 mb-4 text-gray-400 dark:text-gray-500" />
               <div className="text-xl mb-2">No notes found</div>
               <div className="text-sm mb-4 text-center">
@@ -1636,7 +1636,7 @@ export default function BoardPage({
           )}
 
         {notes.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-96 text-gray-500 dark:text-gray-400">
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-500 dark:text-gray-400">
             <div className="text-xl mb-2">No notes yet</div>
             <div className="text-sm mb-4">
               Click &ldquo;Add Note&rdquo; to get started


### PR DESCRIPTION
fixes #188 
**Summary**
In this PR Updated the board page so that empty-state messages for “No notes found” and “No notes yet” are absolutely positioned within the board, keeping them visible without requiring the user to scroll. Added after and before video now.

Before

https://github.com/user-attachments/assets/c73a48a0-2ec4-42a0-a91f-60a4fd00d5dc


After



https://github.com/user-attachments/assets/7c7cd37e-e666-4705-9930-541c40d44be5


