### PR TITLE
fix: whitespace bug

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -224,24 +224,25 @@ export default function BoardPage({
     const actualNotePadding = notePadding || config.notePadding;
     const actualNoteWidth = noteWidth || config.noteWidth;
 
-    const headerHeight = 76; // User info header + margins (more accurate)
+    const headerHeight = 60; // User info header + margins
     const paddingHeight = actualNotePadding * 2; // Top and bottom padding
-    const minContentHeight = 84; // Minimum content area (3 lines)
+    const minContentHeight = 60; // Minimum content area
 
     if (note.checklistItems) {
       // For checklist items, calculate height based on number of items
-      const itemHeight = 32; // Each checklist item is about 32px tall (text + padding)
-      const itemSpacing = 8; // Space between items
+      const itemHeight = 28; // Each checklist item is about 28px tall (more accurate)
+      const itemSpacing = 4; // Space between items (space-y-1 = 4px)
       const checklistItemsCount = note.checklistItems.length;
       const addingItemHeight = addingChecklistItem === note.id ? 32 : 0; // Add height for input field
+      const addTaskButtonHeight = 36; // Height for the "Add task" button including margin
 
       const checklistHeight =
         checklistItemsCount * itemHeight +
-        (checklistItemsCount - 1) * itemSpacing +
+        (checklistItemsCount > 0 ? (checklistItemsCount - 1) * itemSpacing : 0) +
         addingItemHeight;
       const totalChecklistHeight = Math.max(minContentHeight, checklistHeight);
 
-      return headerHeight + paddingHeight + totalChecklistHeight + 40; // Extra space for + button
+      return headerHeight + paddingHeight + totalChecklistHeight + addTaskButtonHeight;
     } else {
       // Original logic for regular notes
       const lines = note.content.split("\n");

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -460,7 +460,7 @@ export function Note({
       </div>
 
       {isEditing ? (
-        <div className="flex-1 min-h-0">
+        <div className="min-h-0">
           <textarea
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
@@ -480,8 +480,8 @@ export function Note({
           />
         </div>
       ) : (
-        <div className="flex-1 flex flex-col">
-          <div className="overflow-y-auto space-y-1 flex-1">
+        <div className="flex flex-col">
+          <div className="overflow-y-auto space-y-1">
             {/* Checklist Items */}
             {note.checklistItems?.map((item) => (
               <ChecklistItemComponent


### PR DESCRIPTION
Fixes: https://github.com/antiwork/gumboard/issues/178

![Screenshot 2025-08-11 at 1 57 54 AM](https://github.com/user-attachments/assets/b2621af5-c6c8-47da-9d82-46bcdadc5564)


  Root Causes:

  1. Flex-1 stretching: The Note component had flex-1 classes on containers (lines 463 and 483 in note.tsx), which caused the content to expand and fill all available vertical space
  within the fixed-height container.
  2. Overestimated height calculations: The calculateNoteHeight function in the board page was calculating too much height for checklist items:
    - Header height was set to 76px (too high)
    - Item height was 32px per checklist item (actual is ~28px)
    - Item spacing was 8px (actual is 4px with space-y-1)
    - Extra padding of 40px for the button

  