### PR TITLE
Fixes: multiple api calls and broken editing on `all-notes` after #184

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -727,62 +727,12 @@ export default function BoardPage({
 
   // Adapter: bridge component Note -> existing update handler
   const handleUpdateNoteFromComponent = async (updatedNote: Note) => {
-    try {
       // Find the note to get its board ID for all notes view
       const currentNote = notes.find((n) => n.id === updatedNote.id);
       if (!currentNote) return;
 
-      const targetBoardId = currentNote?.board?.id ?? currentNote.boardId;
-
       // OPTIMISTIC UPDATE: Update UI immediately
       setNotes(notes.map((n) => (n.id === updatedNote.id ? updatedNote : n)));
-
-      // Send to server in background
-      const response = await fetch(
-        `/api/boards/${targetBoardId}/notes/${updatedNote.id}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            content: updatedNote.content,
-            checklistItems: updatedNote.checklistItems,
-          }),
-        }
-      );
-
-      if (response.ok) {
-        // Server succeeded, confirm with actual server response
-        const { note } = await response.json();
-        setNotes(notes.map((n) => (n.id === updatedNote.id ? note : n)));
-      } else {
-        // Server failed, revert to original note
-        console.error("Server error, reverting optimistic update");
-        setNotes(notes.map((n) => (n.id === updatedNote.id ? currentNote : n)));
-
-        const errorData = await response.json();
-        setErrorDialog({
-          open: true,
-          title: "Failed to update note",
-          description: errorData.error || "Failed to update note",
-        });
-      }
-    } catch (error) {
-      console.error("Error updating note:", error);
-
-      // Revert optimistic update on network error
-      const currentNote = notes.find((n) => n.id === updatedNote.id);
-      if (currentNote) {
-        setNotes(notes.map((n) => (n.id === updatedNote.id ? currentNote : n)));
-      }
-
-      setErrorDialog({
-        open: true,
-        title: "Connection Error",
-        description: "Failed to save note. Please try again.",
-      });
-    }
   };
 
   const handleAddNote = async (targetBoardId?: string) => {
@@ -1240,7 +1190,6 @@ export default function BoardPage({
               key={note.id}
               note={note as Note}
               currentUser={user as User}
-              boardId={boardId || "all-notes"}
               addingChecklistItem={addingChecklistItem}
               onUpdate={handleUpdateNoteFromComponent}
               onDelete={handleDeleteNote}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -53,7 +53,6 @@ export interface Note {
 interface NoteProps {
   note: Note;
   currentUser?: User;
-  boardId: string;
   addingChecklistItem?: string | null;
   onUpdate?: (note: Note) => void;
   onDelete?: (noteId: string) => void;
@@ -67,7 +66,6 @@ interface NoteProps {
 export function Note({
   note,
   currentUser,
-  boardId,
   addingChecklistItem,
   onUpdate,
   onDelete,
@@ -103,8 +101,6 @@ export function Note({
     try {
       if (!note.checklistItems) return;
 
-      const targetBoardId = boardId === "all-notes" && note.board?.id ? note.board.id : boardId;
-
       const updatedItems = note.checklistItems.map((item) =>
         item.id === itemId ? { ...item, checked: !item.checked } : item
       );
@@ -125,7 +121,7 @@ export function Note({
 
       onUpdate?.(optimisticNote);
 
-      fetch(`/api/boards/${targetBoardId}/notes/${note.id}`, {
+      fetch(`/api/boards/${note.boardId}/notes/${note.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -156,8 +152,6 @@ export function Note({
     try {
       if (!note.checklistItems) return;
 
-      const targetBoardId = boardId === "all-notes" && note.board?.id ? note.board.id : boardId;
-
       const updatedItems = note.checklistItems.filter(
         (item) => item.id !== itemId
       );
@@ -170,7 +164,7 @@ export function Note({
       onUpdate?.(optimisticNote);
 
       const response = await fetch(
-        `/api/boards/${targetBoardId}/notes/${note.id}`,
+        `/api/boards/${note.boardId}/notes/${note.id}`,
         {
           method: "PUT",
           headers: {
@@ -199,14 +193,12 @@ export function Note({
     try {
       if (!note.checklistItems) return;
 
-      const targetBoardId = boardId === "all-notes" && note.board?.id ? note.board.id : boardId;
-
       const updatedItems = note.checklistItems.map((item) =>
         item.id === itemId ? { ...item, content } : item
       );
 
       const response = await fetch(
-        `/api/boards/${targetBoardId}/notes/${note.id}`,
+        `/api/boards/${note.boardId}/notes/${note.id}`,
         {
           method: "PUT",
           headers: {
@@ -235,8 +227,6 @@ export function Note({
     try {
       if (!note.checklistItems) return;
 
-      const targetBoardId = boardId === "all-notes" && note.board?.id ? note.board.id : boardId;
-
       const firstHalf = content.substring(0, cursorPosition).trim();
       const secondHalf = content.substring(cursorPosition).trim();
 
@@ -261,7 +251,7 @@ export function Note({
       );
 
       const response = await fetch(
-        `/api/boards/${targetBoardId}/notes/${note.id}`,
+        `/api/boards/${note.boardId}/notes/${note.id}`,
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -282,8 +272,6 @@ export function Note({
 
   const handleAddChecklistItem = async (content: string) => {
     try {
-      const targetBoardId = boardId === "all-notes" && note.board?.id ? note.board.id : boardId;
-
       const newItem = {
         id: `item_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         content,
@@ -304,7 +292,7 @@ export function Note({
       onUpdate?.(optimisticNote);
 
       const response = await fetch(
-        `/api/boards/${targetBoardId}/notes/${note.id}`,
+        `/api/boards/${note.boardId}/notes/${note.id}`,
         {
           method: "PUT",
           headers: {

--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -366,7 +366,6 @@ export function StickyNotesDemo() {
                   currentUser={{ id: "demo-user", name: "Demo User", email: "demo@example.com" }}
                   onUpdate={handleUpdateNote}
                   onDelete={handleDeleteNote}
-                  boardId="demo-board"
                   addingChecklistItem={null}
                   className={`${note.color} bg-white dark:bg-zinc-900 p-4`}
                 />

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -92,8 +92,8 @@ test.describe('Note Management with Newlines', () => {
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
               board: {
-                  id: 'test-board',
-                  name: 'Test Board',
+                id: 'test-board',
+                name: 'Test Board',
               },
               boardId: 'test-board',
               user: {
@@ -173,6 +173,114 @@ test.describe('Note Management with Newlines', () => {
     });
   });
 
+  test('should always use note.boardId for all API calls', async ({ page }) => {
+    let apiCallsMade: { url: string; method: string; }[] = [];
+    
+    const mockNoteData = {
+      id: 'test-note-123',
+      content: 'Original content',
+      color: '#fef3c7',
+      done: false,
+      checklistItems: [{
+        id: 'item-1',
+        content: 'Test item',
+        checked: false,
+        order: 0,
+      }],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      boardId: 'note-actual-board-id',
+      board: {
+        id: 'note-actual-board-id',
+        name: 'Note Actual Board',
+      },
+      user: {
+        id: 'test-user',
+        name: 'Test User',
+        email: 'test@example.com',
+      },
+    };
+    
+    await page.route('**/api/boards/*/notes/*', async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+      console.log("🚀 ~ url:", url)
+      console.log("🚀 ~ method:", method)
+      
+      apiCallsMade.push({
+        url,
+        method,
+      });
+
+      if (method === 'PUT' || method === 'DELETE') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            note: mockNoteData,
+          }),
+        });
+      }
+    });
+
+    await page.route('**/api/boards/all-notes/notes', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            notes: [mockNoteData]
+          }),
+        });
+      }
+    });
+
+    await page.goto('/boards/all-notes');
+
+    // Check for all the actions for notes & checklistitem
+
+    // Test 1: Toggle checklist item 
+    const checkbox = page.locator('[data-state="unchecked"]').first();
+    await expect(checkbox).toBeVisible();
+    await checkbox.click();
+
+    // Test 2: Add a new checklist item 
+    const addTaskButton = page.locator('button:has-text("Add task")');
+    await expect(addTaskButton).toBeVisible();
+    await addTaskButton.click();
+    const newItemInput = page.locator('input[placeholder="Add new item..."]');
+    await expect(newItemInput).toBeVisible();
+    await newItemInput.fill('New test item');
+    await newItemInput.press('Enter');
+
+    // Test 3: Edit checklist item content
+    const existingItem = page.locator('text=Test item').first();
+    await expect(existingItem).toBeVisible();
+    await existingItem.dblclick();
+    const editInput = page.locator('input[value="Test item"]');
+    await editInput.isVisible()
+    await editInput.fill('Edited test item');
+    await page.getByText('Note Actual Board').click();
+
+    // Test 4: Delete checklist item
+    await page.getByRole('button', { name: 'Delete item' }).click();
+
+    // Test 5: Archive Note
+    await page.getByRole('button', { name: 'Archive note' }).click();
+    
+    // Test 6: Delete Note
+    await page.getByRole('button').filter({ hasText: /^$/ }).nth(1).click();
+    await page.getByRole('button', { name: 'Delete note' }).click(); 
+
+    expect(apiCallsMade.filter(call => call.method === 'PUT').length).toBe(5);
+    expect(apiCallsMade.filter(call => call.method === 'DELETE').length).toBe(1);
+    expect(apiCallsMade.length).toBe(6);
+
+    apiCallsMade.forEach(call => {
+      expect(call.url).toContain('api/boards/note-actual-board-id/notes/test-note-123');
+    });
+  });
+
   test('should create a checklist note and verify database state', async ({ page }) => {
     let noteCreated = false;
     let noteData: any = null;
@@ -207,10 +315,10 @@ test.describe('Note Management with Newlines', () => {
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
               board: {
-                  id: 'test-board',
-                  name: 'Test Board',
-                },
-                boardId: 'test-board',
+                id: 'test-board',
+                name: 'Test Board',
+              },
+              boardId: 'test-board',
               user: {
                 id: 'test-user',
                 name: 'Test User',
@@ -296,5 +404,4 @@ test.describe('Note Management with Newlines', () => {
     await page.waitForTimeout(500);
     await expect(page.locator('.note-background')).toBeVisible();
   });
-
 });


### PR DESCRIPTION
Fixes #238

-  #184 refactor broke #222, and this will fix that
- New spec added which checks for note editing action on `all-notes` board

<img width="1427" height="828" alt="" src="https://github.com/user-attachments/assets/6f8950c2-0595-48b3-b4fe-f8c830f7b8dd" />
