### PR TITLE
fix: homepage sticky notes editing after #184

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -76,6 +76,9 @@ export function ChecklistItem({
         "flex items-center group/item rounded gap-3 transition-all duration-200",
         className
       )}
+      // To avoid flaky test locators
+      data-testid={process.env.NODE_ENV !== "production" ? item.id : undefined}
+      data-testorder={process.env.NODE_ENV !== "production" ? item.order : undefined}
     >
       <Checkbox
         checked={item.checked}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -52,6 +52,7 @@ export interface Note {
 
 interface NoteProps {
   note: Note;
+  syncDB?: boolean;
   currentUser?: User;
   addingChecklistItem?: string | null;
   onUpdate?: (note: Note) => void;
@@ -73,6 +74,7 @@ export function Note({
   readonly = false,
   showBoardName = false,
   className,
+  syncDB = true,
   style,
 }: NoteProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -121,28 +123,30 @@ export function Note({
 
       onUpdate?.(optimisticNote);
 
-      fetch(`/api/boards/${note.boardId}/notes/${note.id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          checklistItems: sortedItems,
-        }),
-      })
-        .then(async (response) => {
-          if (!response.ok) {
-            console.error("Server error, reverting optimistic update");
-            onUpdate?.(note);
-          } else {
-            const { note: updatedNote } = await response.json();
-            onUpdate?.(updatedNote);
-          }
+      if (syncDB) {
+        fetch(`/api/boards/${note.boardId}/notes/${note.id}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            checklistItems: sortedItems,
+          }),
         })
-        .catch((error) => {
-          console.error("Error toggling checklist item:", error);
-          onUpdate?.(note);
-        });
+          .then(async (response) => {
+            if (!response.ok) {
+              console.error("Server error, reverting optimistic update");
+              onUpdate?.(note);
+            } else {
+              const { note: updatedNote } = await response.json();
+              onUpdate?.(updatedNote);
+            }
+          })
+          .catch((error) => {
+            console.error("Error toggling checklist item:", error);
+            onUpdate?.(note);
+          });
+      }
     } catch (error) {
       console.error("Error toggling checklist item:", error);
     }
@@ -151,41 +155,41 @@ export function Note({
   const handleDeleteChecklistItem = async (itemId: string) => {
     try {
       if (!note.checklistItems) return;
-
       const updatedItems = note.checklistItems.filter(
         (item) => item.id !== itemId
       );
-
+      
       const optimisticNote = {
         ...note,
         checklistItems: updatedItems,
       };
-
+  
       onUpdate?.(optimisticNote);
 
-      const response = await fetch(
-        `/api/boards/${note.boardId}/notes/${note.id}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            checklistItems: updatedItems,
-          }),
-        }
-      );
+      if (syncDB) {
+        const response = await fetch(
+          `/api/boards/${note.boardId}/notes/${note.id}`,
+          {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              checklistItems: updatedItems,
+            }),
+          }
+        );
 
-      if (response.ok) {
-        const { note: updatedNote } = await response.json();
-        onUpdate?.(updatedNote);
-      } else {
-        console.error("Server error, reverting optimistic update");
-        onUpdate?.(note);
+        if (response.ok) {
+          const { note: updatedNote } = await response.json();
+          onUpdate?.(updatedNote);
+        } else {
+          console.error("Server error, reverting optimistic update");
+          onUpdate?.(note);
+        }
       }
     } catch (error) {
       console.error("Error deleting checklist item:", error);
-      onUpdate?.(note);
     }
   };
 
@@ -197,22 +201,31 @@ export function Note({
         item.id === itemId ? { ...item, content } : item
       );
 
-      const response = await fetch(
-        `/api/boards/${note.boardId}/notes/${note.id}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            checklistItems: updatedItems,
-          }),
-        }
-      );
+      const optimisticNote = {
+        ...note,
+        checklistItems: updatedItems,
+      };
 
-      if (response.ok) {
-        const { note: updatedNote } = await response.json();
-        onUpdate?.(updatedNote);
+      onUpdate?.(optimisticNote);
+
+      if (syncDB) {
+        const response = await fetch(
+          `/api/boards/${note.boardId}/notes/${note.id}`,
+          {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              checklistItems: updatedItems,
+            }),
+          }
+        );
+
+        if (response.ok) {
+          const { note: updatedNote } = await response.json();
+          onUpdate?.(updatedNote);
+        }
       }
     } catch (error) {
       console.error("Error editing checklist item:", error);
@@ -250,20 +263,29 @@ export function Note({
         (a, b) => a.order - b.order
       );
 
-      const response = await fetch(
-        `/api/boards/${note.boardId}/notes/${note.id}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            checklistItems: allItems,
-          }),
-        }
-      );
+      const optimisticNote = {
+        ...note,
+        checklistItems: allItems,
+      };
 
-      if (response.ok) {
-        const { note: updatedNote } = await response.json();
-        onUpdate?.(updatedNote);
+      onUpdate?.(optimisticNote);
+
+      if (syncDB) {
+        const response = await fetch(
+          `/api/boards/${note.boardId}/notes/${note.id}`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              checklistItems: allItems,
+            }),
+          }
+        );
+
+        if (response.ok) {
+          const { note: updatedNote } = await response.json();
+          onUpdate?.(updatedNote);
+        }
       }
     } catch (error) {
       console.error("Error splitting checklist item:", error);
@@ -291,28 +313,29 @@ export function Note({
 
       onUpdate?.(optimisticNote);
 
-      const response = await fetch(
-        `/api/boards/${note.boardId}/notes/${note.id}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            checklistItems: [...(note.checklistItems || []), newItem],
-          }),
-        }
-      );
+      if (syncDB) {
+        const response = await fetch(
+          `/api/boards/${note.boardId}/notes/${note.id}`,
+          {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              checklistItems: [...(note.checklistItems || []), newItem],
+            }),
+          }
+        );
 
-      if (response.ok) {
-        const { note: updatedNote } = await response.json();
-        onUpdate?.(updatedNote);
-      } else {
-        onUpdate?.(note);
+        if (response.ok) {
+          const { note: updatedNote } = await response.json();
+          onUpdate?.(updatedNote);
+        } else {
+          onUpdate?.(note);
+        }
       }
     } catch (error) {
       console.error("Error adding checklist item:", error);
-      onUpdate?.(note);
     }
   };
 
@@ -416,6 +439,7 @@ export function Note({
           {canEdit && (
             <div className="flex space-x-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
               <Button
+                aria-label={`Delete Note ${note.id}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   onDelete?.(note.id);

--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -362,12 +362,13 @@ export function StickyNotesDemo() {
             {notes.map((note) => (
               <motion.div key={note.id} className="mb-4 break-inside-avoid" variants={itemVariants} exit="exit" layout>
                 <NoteComponent
+                  addingChecklistItem={null}
+                  className={`${note.color} bg-white dark:bg-zinc-900 p-4`}
                   note={note}
                   currentUser={{ id: "demo-user", name: "Demo User", email: "demo@example.com" }}
                   onUpdate={handleUpdateNote}
                   onDelete={handleDeleteNote}
-                  addingChecklistItem={null}
-                  className={`${note.color} bg-white dark:bg-zinc-900 p-4`}
+                  syncDB={false}
                 />
               </motion.div>
             ))}

--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home Page', () => {
+  test('sticky notes demo - should handle all UI interactions correctly', async ({ page }) => {
+    let networkCalls: number = 0;
+
+    await page.route('**/api/boards/*/notes/*', async (route) => {
+      const method = route.request().method();
+      if (method === 'PUT' || method === 'DELETE') {
+          networkCalls += 1;
+      }
+    });
+
+    await page.goto('/');
+    await expect(page.locator('text=Keep on top of your team\'s to-dos')).toBeVisible();
+    let initialNotes = await page.getByRole('button', { name: 'Add task' }).count();
+
+    // Test 1: Add a new note
+    await page.getByRole('button', { name: 'Add Note' }).click();
+    await expect(page.getByText('New to-do')).toBeVisible();
+    await expect(await page.getByRole('button', { name: 'Add task' }).count()).toBe(initialNotes + 1);
+    initialNotes += 1;
+
+    // Test 2: Toggle checklist item (check/uncheck)
+    const initialCheckedCount = await page.getByRole('checkbox', { checked: true }).count();
+    const uncheckedCheckbox = page.getByTestId('102').getByRole('checkbox');
+    await uncheckedCheckbox.click();
+    await expect(await page.getByRole('checkbox', { checked: true })).toHaveCount(initialCheckedCount + 1);
+    await uncheckedCheckbox.click();
+    await expect(page.getByRole('checkbox', { checked: true })).toHaveCount(initialCheckedCount);
+
+    // Test 3: Add a new checklist item
+    await page.getByRole('button', { name: 'Add task' }).first().click();
+    await page.getByPlaceholder('Add new item...').fill('Brand new task item');
+    await page.getByPlaceholder('Add new item...').press('Enter');
+    await expect(page.getByText('Brand new task item')).toBeVisible();
+
+    // Test 4: Edit existing checklist item content
+    await page.getByText('Gumboard release by Friday').click();
+    const editInput = page.locator('input[value="Gumboard release by Friday"]');
+    await expect(editInput).toBeVisible();
+    await editInput.fill('Updated Gumboard release deadline');
+    await page.getByText('Sahil').click();
+    await expect(page.getByText('Updated Gumboard release deadline')).toBeVisible();
+
+    // Test 5: Delete a checklist item
+    page.getByTestId('101').getByRole('button', { name: 'Delete item', exact: true }).click();
+    await expect(page.getByTestId('101')).not.toBeAttached()
+
+    // Test 6: Delete entire note
+    const deleteNoteButton = page.getByRole('button', { name: 'Delete Note 1', exact: true });
+    await deleteNoteButton.click();
+    await expect(deleteNoteButton).not.toBeAttached();
+    await expect(await page.getByRole('button', { name: 'Add task' }).count()).toBe(initialNotes - 1);
+    initialNotes -= 1;
+
+    // Test 7: Split checklist item (Enter in middle of text)
+    const itemToSplit = page.getByText('Helper Tix (Mon-Fri)');
+    await itemToSplit.click();
+    const editSplitInput = page.locator('input[value="Helper Tix (Mon-Fri)"]');
+    if (await editSplitInput.isVisible()) {
+        await editSplitInput.click();
+        await editSplitInput.press('ArrowLeft');
+        await editSplitInput.press('ArrowLeft');
+        await editSplitInput.press('ArrowLeft');
+        await editSplitInput.press('Enter');
+    }
+    await expect(page.getByTestId('203')).toBeVisible();
+    await expect(page.getByText('(Mon-Fri)')).toBeVisible();
+
+    expect(networkCalls).toBe(0);
+  });
+});

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -204,8 +204,6 @@ test.describe('Note Management with Newlines', () => {
     await page.route('**/api/boards/*/notes/*', async (route) => {
       const url = route.request().url();
       const method = route.request().method();
-      console.log("🚀 ~ url:", url)
-      console.log("🚀 ~ method:", method)
       
       apiCallsMade.push({
         url,


### PR DESCRIPTION
Fixes #240

#184 broke the homepage and below is what I did to resolve it

- Added a `syncDB` prop to `Note` component. It defaults to `true` and when set to `false` will not synchronize it's state with database allowing local edits
- I added spec because things are moving fast and home page with bugs won't look good on the brand. I think this will help with mobility without breaking stuff


### Before and after video

https://github.com/user-attachments/assets/7b17c1ce-487e-410c-a97f-3a4ee18dc512


## Tests passing

<img width="1469" height="918" alt="tests_passing" src="https://github.com/user-attachments/assets/87fba772-844a-47ad-b43d-e77f77338676" />

