### PR TITLE
chore: replace .env.local with .env file in README Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ To enable login with Google, follow these steps:
    ```
    http://localhost:3000/api/auth/callback/google
    ```
-   _(Replace with your production URL if deploying)_
-
+   *(Replace with your production URL if deploying)*
 ---
 
 ### 2. Add Environment Variables

--- a/README.md
+++ b/README.md
@@ -18,16 +18,19 @@ npm install
 ### Database Setup
 
 1. Create your environment variables file:
+
 ```bash
-cp env.example .env.local
+cp env.example .env
 ```
 
 2. Start the PostgreSQL database using Docker:
+
 ```bash
 npm run docker:up
 ```
 
 3. Push the database schema:
+
 ```bash
 npm run db:push
 ```
@@ -76,7 +79,7 @@ To enable login with Google, follow these steps:
    ```
    http://localhost:3000/api/auth/callback/google
    ```
-   *(Replace with your production URL if deploying)*
+   _(Replace with your production URL if deploying)_
 
 ---
 


### PR DESCRIPTION
fixes #259 

`npm run db:push` fails when using `.env.local` file 

<img width="675" height="702" alt="image" src="https://github.com/user-attachments/assets/29ec6a37-245f-44fd-a888-10deef152aa9" />

more context: https://github.com/prisma/prisma/issues/3865

when using `.env.local` file, prisma db push fails

<img width="586" height="485" alt="image" src="https://github.com/user-attachments/assets/530dcf56-a608-492f-9195-67bdb8d5d994" />

when using `.env` file, prisma db push runs ok

<img width="705" height="403" alt="image" src="https://github.com/user-attachments/assets/c43b6e90-ac7e-4d79-9893-f06e50de8d77" />
