### PR TITLE
refactor: migrate dropdown to shadcn popover in settings page

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -23,12 +23,7 @@ import {
 import type { Note, Board, User } from "@/components/note";
 import { useTheme } from "next-themes";
 import { Navbar } from "@/components/navbar";
-import { 
-  BoardSelector, 
-  SearchBar, 
-  Filter, 
-  AddNoteButton 
-} from "@/components/board-actions";
+import { BoardSelector, SearchBar, Filter, AddNoteButton } from "@/components/board-actions";
 
 export default function BoardPage({ params }: { params: Promise<{ id: string }> }) {
   const [board, setBoard] = useState<Board | null>(null);
@@ -870,7 +865,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   return (
     <div className="min-h-screen max-w-screen bg-background dark:bg-zinc-950">
-      <Navbar 
+      <Navbar
         user={user}
         boardActions={
           <>
@@ -902,11 +897,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               setDebouncedSearchTerm={setDebouncedSearchTerm}
               updateURL={updateURL}
             />
-            <AddNoteButton
-              onAddNote={handleAddNote}
-              boardId={boardId}
-              allBoards={allBoards}
-            />
+            <AddNoteButton onAddNote={handleAddNote} boardId={boardId} allBoards={allBoards} />
           </>
         }
       />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import z from "zod";
 
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { Button } from "@/components/ui/button"
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import Link from "next/link";
 import { useState, useEffect } from "react";
@@ -32,7 +32,14 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Navbar } from "@/components/navbar";
 import { AddBoardButton } from "@/components/board-actions";
 
@@ -265,12 +272,12 @@ export default function Dashboard() {
       form.reset();
       setEditingBoard(null);
     }
-  }
+  };
 
   const handleAddBoardClick = () => {
     form.reset({ name: "", description: "" });
     setIsAddBoardDialogOpen(true);
-    setEditingBoard(null); 
+    setEditingBoard(null);
   };
 
   if (loading) {
@@ -279,12 +286,7 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen bg-background dark:bg-zinc-950">
-      <Navbar 
-        user={user} 
-        userActions={
-          <AddBoardButton onAddBoard={handleAddBoardClick} />
-        }
-      />
+      <Navbar user={user} userActions={<AddBoardButton onAddBoard={handleAddBoardClick} />} />
       <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         {boards.length > 0 && (
           <div className="mb-6 sm:mb-8">

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react"
-import { useRouter, usePathname } from "next/navigation"
-import { User as UserIcon, Building2, ArrowLeft } from "lucide-react"
-import Link from "next/link"
-import { FullPageLoader } from "@/components/ui/loader"
-import type { User } from "@/components/note"
-import { Navbar } from "@/components/navbar"
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { User as UserIcon, Building2, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { FullPageLoader } from "@/components/ui/loader";
+import type { User } from "@/components/note";
+import { Navbar } from "@/components/navbar";
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);

--- a/components/board-actions.tsx
+++ b/components/board-actions.tsx
@@ -2,13 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import {
-  Plus,
-  Search,
-  ChevronDown,
-  Pencil,
-  Settings,
-} from "lucide-react";
+import { Plus, Search, ChevronDown, Pencil, Settings } from "lucide-react";
 import type { Board } from "@/components/note";
 import { FilterPopover } from "@/components/ui/filter-popover";
 
@@ -24,10 +18,10 @@ interface BoardSelectorProps {
 }
 
 interface SearchBarProps {
-    searchTerm?: string;
-    setSearchTerm?: (term: string) => void;
-    setDebouncedSearchTerm?: (term: string) => void;
-    updateURL?: (searchTerm?: string) => void;
+  searchTerm?: string;
+  setSearchTerm?: (term: string) => void;
+  setDebouncedSearchTerm?: (term: string) => void;
+  updateURL?: (searchTerm?: string) => void;
 }
 
 interface AddNoteButtonProps {
@@ -37,7 +31,7 @@ interface AddNoteButtonProps {
 }
 
 interface AddBoardButtonProps {
-    onAddBoard?: () => void;
+  onAddBoard?: () => void;
 }
 
 export function BoardSelector({
@@ -145,8 +139,7 @@ export function BoardSelector({
                 onClick={() => {
                   setBoardSettings?.({
                     sendSlackUpdates:
-                      (board as { sendSlackUpdates?: boolean })
-                        ?.sendSlackUpdates ?? true,
+                      (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
                   });
                   setBoardSettingsDialog?.(true);
                   setShowBoardDropdown?.(false);
@@ -210,7 +203,11 @@ interface FilterProps {
   selectedAuthor?: string | null;
   setSelectedAuthor?: (authorId: string | null) => void;
   uniqueAuthors?: Array<{ id: string; name: string; email: string }>;
-  updateURL?: (searchTerm?: string, dateRange?: { startDate: Date | null; endDate: Date | null }, authorId?: string | null) => void;
+  updateURL?: (
+    searchTerm?: string,
+    dateRange?: { startDate: Date | null; endDate: Date | null },
+    authorId?: string | null
+  ) => void;
 }
 
 export function Filter({
@@ -243,11 +240,7 @@ export function Filter({
   );
 }
 
-export function AddNoteButton({
-  onAddNote,
-  boardId,
-  allBoards = [],
-}: AddNoteButtonProps) {
+export function AddNoteButton({ onAddNote, boardId, allBoards = [] }: AddNoteButtonProps) {
   return (
     <Button
       onClick={() => {
@@ -274,4 +267,4 @@ export function AddBoardButton({ onAddBoard }: AddBoardButtonProps) {
       <span className="hidden sm:inline">Add Board</span>
     </Button>
   );
-} 
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -13,15 +13,14 @@ interface NavbarProps {
   className?: string;
 }
 
-export function Navbar({ 
-  user, 
-  boardActions,
-  userActions,
-  className
-}: NavbarProps) {
-
+export function Navbar({ user, boardActions, userActions, className }: NavbarProps) {
   return (
-    <nav className={cn("bg-card dark:bg-zinc-900 border-b border-gray-200 dark:border-zinc-800 shadow-sm", className)}>
+    <nav
+      className={cn(
+        "bg-card dark:bg-zinc-900 border-b border-gray-200 dark:border-zinc-800 shadow-sm",
+        className
+      )}
+    >
       <div className="flex justify-between items-center h-16 px-4 sm:px-6 lg:px-8">
         <div className="flex items-center space-x-4">
           <div className="flex-shrink-0">
@@ -35,7 +34,9 @@ export function Navbar({
           {boardActions && <div className="flex items-center space-x-4">{boardActions}</div>}
         </div>
         <div className="flex items-center space-x-2 sm:space-x-4">
-          {userActions && <div className="flex items-center space-x-2 sm:space-x-4">{userActions}</div>}
+          {userActions && (
+            <div className="flex items-center space-x-2 sm:space-x-4">{userActions}</div>
+          )}
           <ProfileDropdown user={user} />
         </div>
       </div>

--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -7,48 +7,56 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { User } from "@/components/note";
 
 interface ProfileDropdownProps {
-    user: User | null;
+  user: User | null;
 }
 
 export function ProfileDropdown({ user }: ProfileDropdownProps) {
-    const handleSignOut = async () => {
-        await signOut();
-    };
-    return (
-        <Popover>
-            <PopoverTrigger asChild>
-                <Avatar className="w-9 h-9 cursor-pointer">
-                <div className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors ">
-                <AvatarImage className="w-7 h-7 rounded-full" src={user?.image || ""} alt={user?.name || ""} />
-                <AvatarFallback className="w-8 h-8 flex items-center justify-center rounded-full text-zinc-900 dark:text-zinc-100 bg-blue-500 ">
-                    <span className="text-sm font-medium text-white">
-                        {user?.name
-                        ? user.name.charAt(0).toUpperCase()
-                        : user?.email?.charAt(0).toUpperCase()}
-                    </span>
-                    </AvatarFallback>
-                </div>
-                </Avatar>
-            </PopoverTrigger>
-            <PopoverContent className="w-80 bg-white dark:bg-zinc-900"> 
-                <div>
-                    <p className="font-medium text-zinc-900 dark:text-zinc-100">
-                        {user?.name || user?.email}
-                    </p>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {user?.email}
-                    </p>
-                    <Link href={"/settings"} className="flex items-center mt-4 hover:bg-zinc-200 dark:hover:bg-zinc-800  pl-2 dark:hover:text-zinc-50 text-zinc-800 dark:text-zinc-400 rounded-md text-sm gap-2 py-2">
-                        <Settings size={19} />
-                        Settings
-                    </Link>
+  const handleSignOut = async () => {
+    await signOut();
+  };
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Avatar className="w-9 h-9 cursor-pointer">
+          <div className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors ">
+            <AvatarImage
+              className="w-7 h-7 rounded-full"
+              src={user?.image || ""}
+              alt={user?.name || ""}
+            />
+            <AvatarFallback className="w-8 h-8 flex items-center justify-center rounded-full text-zinc-900 dark:text-zinc-100 bg-blue-500 ">
+              <span className="text-sm font-medium text-white">
+                {user?.name
+                  ? user.name.charAt(0).toUpperCase()
+                  : user?.email?.charAt(0).toUpperCase()}
+              </span>
+            </AvatarFallback>
+          </div>
+        </Avatar>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 bg-white dark:bg-zinc-900">
+        <div>
+          <p className="font-medium text-zinc-900 dark:text-zinc-100">
+            {user?.name || user?.email}
+          </p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">{user?.email}</p>
+          <Link
+            href={"/settings"}
+            className="flex items-center mt-4 hover:bg-zinc-200 dark:hover:bg-zinc-800  pl-2 dark:hover:text-zinc-50 text-zinc-800 dark:text-zinc-400 rounded-md text-sm gap-2 py-2"
+          >
+            <Settings size={19} />
+            Settings
+          </Link>
 
-                    <div onClick={handleSignOut} className="flex items-center mt-2 group hover:bg-zinc-200 dark:hover:bg-zinc-800 pl-2 text-red-700 dark:hover:text-red-500 rounded-md cursor-pointer text-sm gap-2 py-2">
-                        <LogOut size={19} />
-                            Sign Out
-                    </div>
-                </div>
-            </PopoverContent>
-        </Popover>
-    )
+          <div
+            onClick={handleSignOut}
+            className="flex items-center mt-2 group hover:bg-zinc-200 dark:hover:bg-zinc-800 pl-2 text-red-700 dark:hover:text-red-500 rounded-md cursor-pointer text-sm gap-2 py-2"
+          >
+            <LogOut size={19} />
+            Sign Out
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }


### PR DESCRIPTION
This PR refactors the Settings page by replacing the existing dropdown  with a ShadCN Popover, aligning it with the implementation on the Dashboard page.

<img width="1920" height="848" alt="image" src="https://github.com/user-attachments/assets/5c1b636c-4c57-4ce0-a324-667a491b0343" />
