### PR TITLE
fix(ui): added darkmode styling to close-dialog icon

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-zinc-800 dark:text-zinc-200"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
## Description 

Cross icon in the dialog box was not visible in dark mode, fixed it's styling

Before (x not visible)
<img width="3072" height="1728" alt="Screenshot from 2025-08-12 00-40-26" src="https://github.com/user-attachments/assets/7b10d958-92ec-44b5-99e4-57c1bf63da3a" />

After
<img width="3072" height="1728" alt="Screenshot from 2025-08-12 00-40-53" src="https://github.com/user-attachments/assets/c90958cf-2679-4112-8dd6-00a7c2df45b7" />
