### PR TITLE
fix(ui): prevent notes count text from wrapping

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -432,7 +432,7 @@ export default function Dashboard() {
                         <CardTitle className="text-lg  w-3/4 dark:text-zinc-100">
                           {board.name}
                         </CardTitle>
-                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium text-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
                           {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
                         </span>
                       </div>


### PR DESCRIPTION
# Description
prevent notes count from wrapping by adding `text-nowrap` 

## BEFORE
<img width="3072" height="1728" alt="Screenshot from 2025-08-12 11-21-00" src="https://github.com/user-attachments/assets/4f6d7ccc-d77b-4f33-bda7-5d0e392c6203" />

## AFTER 
<img width="3072" height="1728" alt="Screenshot from 2025-08-12 11-25-57" src="https://github.com/user-attachments/assets/72c0d816-bf65-48c4-9906-e124a454a362" />
