### PR TITLE
fix typo in readme `env.example`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install
 1. Create your environment variables file:
 
 ```bash
-cp env.example .env
+cp .env.example .env
 ```
 
 2. Start the PostgreSQL database using Docker:


### PR DESCRIPTION
I needed to run `cp .env.example .env`. I think there was a typo.