### PR TITLE
feat(migration): add archivedAt column to notes and remove done column

### DIFF
--- a/prisma/migrations/20250812162423_add_archived_at_to_note/migration.sql
+++ b/prisma/migrations/20250812162423_add_archived_at_to_note/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `done` on the `notes` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "notes" ADD COLUMN "archivedAt" TIMESTAMP(3);
+
+-- Set archivedAt to current timestamp for notes where done was true
+UPDATE "notes" SET "archivedAt" = NOW() WHERE "done" = true;
+
+-- Drop the done column
+ALTER TABLE "notes" DROP COLUMN "done";


### PR DESCRIPTION
This migration introduces the `archivedAt` timestamp column to the `notes` table, setting its value for existing notes where `done` was true. The `done` column is subsequently dropped, completing the transition to the new field structure. This change aligns with previous updates to ensure consistency in the database schema.