### PR TITLE
Improve dialogs

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -322,7 +322,7 @@ export default function Dashboard() {
         )}
 
         <Dialog open={isAddBoardDialogOpen} onOpenChange={handleOpenChange}>
-          <DialogContent className="bg-white dark:bg-zinc-950 border border-zinc-800 dark:border-zinc-800 sm:max-w-[425px] ">
+          <DialogContent className="bg-white dark:bg-zinc-950 border border-zinc-300 dark:border-zinc-800 sm:max-w-[425px] ">
             <DialogHeader>
               <DialogTitle className="text-lg font-semibold mb-4 text-foreground dark:text-zinc-100">
                 {editingBoard ? "Edit Board" : "Create New Board"}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-zinc-800 dark:text-zinc-200"
+            className="ring-offset-background hover:bg-neutral-100 p-1  cursor-pointer focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5 text-zinc-800 dark:text-zinc-200"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
before:
also no cursor-pointer on close button
<img width="471" height="382" alt="image" src="https://github.com/user-attachments/assets/8f033e84-670d-464d-97ef-cc9731e77c7e" />



https://github.com/user-attachments/assets/45b1dc32-e822-4d20-8162-711493557de8


why?

unnecessary dark border on light mode(ruins the contrast)