### PR TITLE
fix: persist checklist item order after drag-and-drop

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -244,9 +244,11 @@ export function Note({
         return;
       }
 
+      const updatedItems = newItems.map((item, index) => ({ ...item, order: index }));
+
       const optimisticNote = {
         ...note,
-        checklistItems: newItems.map((items, index) => ({ ...items, order: index })),
+        checklistItems: updatedItems,
       };
 
       onUpdate?.(optimisticNote);
@@ -258,7 +260,7 @@ export function Note({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            checklistItems: newItems,
+            checklistItems: updatedItems,
             archivedAt: allItemsChecked ? new Date().toISOString() : null,
           }),
         });


### PR DESCRIPTION
This PR fixes checklist reordering not persisting after refresh. The UI now recalculates order for each item on drag-and-drop and sends the updated list to the notes update API, ensuring the new order is saved.

Before:
https://github.com/user-attachments/assets/24fb606c-5925-4f2b-9764-56c5e19490a4

After:
https://github.com/user-attachments/assets/19d243ab-9dbb-4963-8ca5-b95c8a66abc6

