### PR TITLE
Fix: checklist items overflows the note

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1103,7 +1103,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 left: note.x,
                 top: note.y,
                 width: note.width,
-                height: note.height,
                 padding: `${getResponsiveConfig().notePadding}px`,
                 backgroundColor: resolvedTheme === "dark" ? "#18181B" : note.color,
               }}

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -121,7 +121,7 @@ export function ChecklistItem({
           ref={editItemInputRef}
           onChange={(e) => onEditContentChange?.(e.target.value)}
           className={cn(
-            "h-auto min-h-0 flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0 resize-none break-all overflow-wrap-anywhere whitespace-pre-wrap",
+            "h-auto min-h-0 flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0 resize-none break-all word-wrap whitespace-pre-wrap",
             item.checked && "text-slate-500 dark:text-zinc-500 line-through"
           )}
           onBlur={handleBlur}
@@ -132,7 +132,7 @@ export function ChecklistItem({
       ) : (
         <span
           className={cn(
-            "flex-1 text-sm leading-6 cursor-pointer select-none break-all overflow-wrap-anywhere whitespace-pre-wrap",
+            "flex-1 text-sm leading-6 cursor-pointer select-none break-all word-wrap whitespace-pre-wrap",
             item.checked
               ? "line-through text-gray-500 dark:text-gray-400"
               : "text-gray-900 dark:text-gray-100",

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -2,10 +2,12 @@
 
 import * as React from "react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Trash2 } from "lucide-react";
+import { Textarea } from "./ui/textarea";
+import { useEffect } from "react";
+import { useRef } from "react";
 
 export interface ChecklistItem {
   id: string;
@@ -45,8 +47,8 @@ export function ChecklistItem({
   showDeleteButton = true,
   className,
 }: ChecklistItemProps) {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       const target = e.target as HTMLInputElement;
       const cursorPosition = target.selectionStart || 0;
@@ -70,6 +72,21 @@ export function ChecklistItem({
     onStopEdit?.();
   };
 
+  const autoResizeTextarea = (textarea: HTMLTextAreaElement | null) => {
+    if (textarea) {
+      textarea.style.height = "auto";
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  };
+
+  const editItemInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if(editItemInputRef.current) {
+      autoResizeTextarea(editItemInputRef.current)
+    }
+  }, [isEditing, editContent])
+
   return (
     <div
       className={cn(
@@ -88,16 +105,17 @@ export function ChecklistItem({
       />
 
       {isEditing && !readonly ? (
-        <Input
-          type="text"
+        <Textarea
           value={editContent ?? item.content}
+          ref={editItemInputRef}
           onChange={(e) => onEditContentChange?.(e.target.value)}
           className={cn(
-            "h-auto flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0",
+            "h-auto flex-1 border-none bg-transparent resize-none p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0",
             item.checked && "text-slate-500 dark:text-zinc-500 line-through"
           )}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
+          draggable={false}
           autoFocus
         />
       ) : (

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -110,7 +110,7 @@ export function ChecklistItem({
           ref={editItemInputRef}
           onChange={(e) => onEditContentChange?.(e.target.value)}
           className={cn(
-            "h-auto flex-1 border-none bg-transparent resize-none p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0",
+            "h-auto flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0 resize-none break-words whitespace-pre-wrap word-wrap overflow-wrap",
             item.checked && "text-slate-500 dark:text-zinc-500 line-through"
           )}
           onBlur={handleBlur}
@@ -121,7 +121,7 @@ export function ChecklistItem({
       ) : (
         <span
           className={cn(
-            "flex-1 text-sm leading-6 cursor-pointer select-none",
+            "flex-1 text-sm leading-6 cursor-pointer select-none break-words whitespace-pre-wrap word-wrap overflow-wrap",
             item.checked
               ? "line-through text-gray-500 dark:text-gray-400"
               : "text-gray-900 dark:text-gray-100",

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -75,7 +75,8 @@ export function ChecklistItem({
   const autoResizeTextarea = (textarea: HTMLTextAreaElement | null) => {
     if (textarea) {
       textarea.style.height = "auto";
-      textarea.style.height = `${textarea.scrollHeight}px`;
+      const newHeight = Math.max(28, textarea.scrollHeight); // Minimum height of ~28px for single line
+      textarea.style.height = `${newHeight}px`;
     }
   };
 
@@ -87,10 +88,20 @@ export function ChecklistItem({
     }
   }, [isEditing, editContent])
 
+  useEffect(() => {
+    if (isEditing && editItemInputRef.current) {
+      const textarea = editItemInputRef.current;
+      textarea.focus();
+      // Set cursor to end of text
+      const length = textarea.value.length;
+      textarea.setSelectionRange(length, length);
+    }
+  }, [isEditing]);
+
   return (
     <div
       className={cn(
-        "flex items-center group/item rounded gap-3 transition-all duration-200",
+        "flex items-start group/item rounded gap-3 transition-all duration-200",
         className
       )}
       // To avoid flaky test locators
@@ -100,7 +111,7 @@ export function ChecklistItem({
       <Checkbox
         checked={item.checked}
         onCheckedChange={() => !readonly && onToggle?.(item.id)}
-        className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:border-zinc-600"
+        className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:border-zinc-600 mt-1"
         disabled={readonly}
       />
 
@@ -110,7 +121,7 @@ export function ChecklistItem({
           ref={editItemInputRef}
           onChange={(e) => onEditContentChange?.(e.target.value)}
           className={cn(
-            "h-auto flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0 resize-none break-words whitespace-pre-wrap word-wrap overflow-wrap",
+            "h-auto min-h-0 flex-1 border-none bg-transparent p-0 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0 resize-none break-all overflow-wrap-anywhere whitespace-pre-wrap",
             item.checked && "text-slate-500 dark:text-zinc-500 line-through"
           )}
           onBlur={handleBlur}
@@ -121,7 +132,7 @@ export function ChecklistItem({
       ) : (
         <span
           className={cn(
-            "flex-1 text-sm leading-6 cursor-pointer select-none break-words whitespace-pre-wrap word-wrap overflow-wrap",
+            "flex-1 text-sm leading-6 cursor-pointer select-none break-all overflow-wrap-anywhere whitespace-pre-wrap",
             item.checked
               ? "line-through text-gray-500 dark:text-gray-400"
               : "text-gray-900 dark:text-gray-100",

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -286,6 +286,10 @@ export function Note({
       const firstHalf = content.substring(0, cursorPosition).trim();
       const secondHalf = content.substring(cursorPosition).trim();
 
+      if (firstHalf.length === 0 || secondHalf.length === 0) {
+        return;
+      }
+
       const updatedItems = note.checklistItems.map((item) =>
         item.id === itemId ? { ...item, content: firstHalf } : item
       );

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import {
   ChecklistItem as ChecklistItemComponent,
   ChecklistItem,
@@ -15,6 +14,7 @@ import { DraggableRoot, DraggableContainer, DraggableItem } from "@/components/u
 import { cn } from "@/lib/utils";
 import { Trash2, Plus, Archive, ArchiveRestore } from "lucide-react";
 import { useTheme } from "next-themes";
+import { Textarea } from "./ui/textarea";
 
 // Core domain types
 export interface User {
@@ -97,7 +97,7 @@ export function Note({
       (!note.checklistItems || note.checklistItems.length === 0)
   );
   const [newItemContent, setNewItemContent] = useState("");
-  const newItemInputRef = useRef<HTMLInputElement>(null);
+  const newItemInputRef = useRef<HTMLTextAreaElement>(null);
 
   const canEdit = !readonly && (currentUser?.id === note.user.id || currentUser?.isAdmin);
 
@@ -429,17 +429,27 @@ export function Note({
     handleAddItem();
   };
 
-  const handleKeyDownNewItem = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDownNewItem = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Escape") {
       setAddingItem(false);
       setNewItemContent("");
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      handleAddItem();
+    }
+  };
+
+  const autoResizeTextarea = (textarea: HTMLTextAreaElement | null) => {
+    if (textarea) {
+      textarea.style.height = "auto";
+      textarea.style.height = `${textarea.scrollHeight}px`;
     }
   };
 
   return (
     <div
       className={cn(
-        "rounded-lg shadow-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border",
+        "rounded-lg shadow-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border min-h-fit",
         className
       )}
       style={{
@@ -526,12 +536,14 @@ export function Note({
 
       {isEditing ? (
         <div className="min-h-0">
-          <textarea
+          <Textarea
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
-            className="w-full h-full p-2 bg-transparent border-none resize-none focus:outline-none text-base leading-7 text-gray-800 dark:text-gray-200"
+            className="w-full h-full resize-none p-2 bg-transparent border-none focus:outline-none text-base leading-7 text-gray-800 dark:text-gray-200"
             placeholder="Enter note content..."
             onBlur={handleStopEdit}
+            rows={1}
+            draggable={false}
             onKeyDown={(e) => {
               if (e.key === "Enter" && e.ctrlKey) {
                 handleStopEdit();
@@ -546,7 +558,7 @@ export function Note({
         </div>
       ) : (
         <div className="flex flex-col">
-          <div className="overflow-y-auto space-y-1">
+          <div className="space-y-1">
             {/* Checklist Items */}
             <DraggableRoot
               items={note.checklistItems ?? []}
@@ -582,15 +594,19 @@ export function Note({
                     disabled
                     className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:border-zinc-600"
                   />
-                  <Input
+                  <Textarea
                     ref={newItemInputRef}
-                    type="text"
                     value={newItemContent}
-                    onChange={(e) => setNewItemContent(e.target.value)}
-                    className="h-auto shadow-none flex-1 border-none bg-transparent px-1 py-0.5 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0"
+                    onChange={(e) => {
+                      autoResizeTextarea(e.currentTarget)
+                      setNewItemContent(e.target.value)
+                    }}
+                    className="min-h-3 shadow-none border-none resize-none flex-1 bg-transparent px-1 py-0.5 text-sm text-zinc-900 dark:text-zinc-100 focus-visible:ring-0 focus-visible:ring-offset-0"
                     placeholder="Add new item..."
                     onKeyDown={handleKeyDownNewItem}
                     onBlur={handleAddItem}
+                    rows={1}
+                    draggable={false}
                     autoFocus
                   />
                   <div className="flex space-x-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/tests/checklist-item.test.ts
+++ b/tests/checklist-item.test.ts
@@ -1,0 +1,76 @@
+import type { ChecklistItem as ChecklistItemType } from "@/components/checklist-item";
+
+const mockItem: ChecklistItemType = {
+  id: "test-item-1",
+  content: "Test item content",
+  checked: false,
+  order: 0,
+};
+
+const longTextItem: ChecklistItemType = {
+  id: "test-item-2",
+  content:
+    "This is an extremely long task description that goes on and on and contains many words to test how our migration handles very long content that might cause issues with database storage or JSON formatting when converted to checklist items and we want to make sure it works correctly without truncation or corruption of the data",
+  checked: false,
+  order: 1,
+};
+
+describe("ChecklistItem Type Tests", () => {
+  it("should have correct structure for regular items", () => {
+    expect(mockItem.id).toBe("test-item-1");
+    expect(mockItem.content).toBe("Test item content");
+    expect(mockItem.checked).toBe(false);
+    expect(mockItem.order).toBe(0);
+  });
+
+  it("should handle long text content properly", () => {
+    expect(longTextItem.id).toBe("test-item-2");
+    expect(longTextItem.content).toContain("extremely long task description");
+    expect(longTextItem.content.length).toBeGreaterThan(100);
+    expect(longTextItem.checked).toBe(false);
+    expect(longTextItem.order).toBe(1);
+  });
+
+  it("should maintain type safety for required fields", () => {
+    const requiredFields = ["id", "content", "checked", "order"];
+
+    requiredFields.forEach((field) => {
+      expect(mockItem).toHaveProperty(field);
+      expect(longTextItem).toHaveProperty(field);
+    });
+  });
+
+  it("should handle checked state changes", () => {
+    const checkedItem: ChecklistItemType = {
+      ...mockItem,
+      checked: true,
+    };
+
+    expect(checkedItem.checked).toBe(true);
+    expect(checkedItem.id).toBe(mockItem.id);
+    expect(checkedItem.content).toBe(mockItem.content);
+  });
+
+  it("should handle order changes for reordering", () => {
+    const reorderedItem: ChecklistItemType = {
+      ...longTextItem,
+      order: 5,
+    };
+
+    expect(reorderedItem.order).toBe(5);
+    expect(reorderedItem.id).toBe(longTextItem.id);
+    expect(reorderedItem.content).toBe(longTextItem.content);
+  });
+
+  it("should handle content updates", () => {
+    const updatedItem: ChecklistItemType = {
+      ...mockItem,
+      content: "Updated content that is longer than the original",
+    };
+
+    expect(updatedItem.content).toBe("Updated content that is longer than the original");
+    expect(updatedItem.id).toBe(mockItem.id);
+    expect(updatedItem.checked).toBe(mockItem.checked);
+    expect(updatedItem.order).toBe(mockItem.order);
+  });
+});

--- a/tests/components/checklist-item.test.ts
+++ b/tests/components/checklist-item.test.ts
@@ -1,0 +1,76 @@
+import type { ChecklistItem as ChecklistItemType } from "@/components/checklist-item";
+
+const mockItem: ChecklistItemType = {
+  id: "test-item-1",
+  content: "Test item content",
+  checked: false,
+  order: 0,
+};
+
+const longTextItem: ChecklistItemType = {
+  id: "test-item-2",
+  content:
+    "This is an extremely long task description that goes on and on and contains many words to test how our migration handles very long content that might cause issues with database storage or JSON formatting when converted to checklist items and we want to make sure it works correctly without truncation or corruption of the data",
+  checked: false,
+  order: 1,
+};
+
+describe("ChecklistItem Type Tests", () => {
+  it("should have correct structure for regular items", () => {
+    expect(mockItem.id).toBe("test-item-1");
+    expect(mockItem.content).toBe("Test item content");
+    expect(mockItem.checked).toBe(false);
+    expect(mockItem.order).toBe(0);
+  });
+
+  it("should handle long text content properly", () => {
+    expect(longTextItem.id).toBe("test-item-2");
+    expect(longTextItem.content).toContain("extremely long task description");
+    expect(longTextItem.content.length).toBeGreaterThan(100);
+    expect(longTextItem.checked).toBe(false);
+    expect(longTextItem.order).toBe(1);
+  });
+
+  it("should maintain type safety for required fields", () => {
+    const requiredFields = ["id", "content", "checked", "order"];
+
+    requiredFields.forEach((field) => {
+      expect(mockItem).toHaveProperty(field);
+      expect(longTextItem).toHaveProperty(field);
+    });
+  });
+
+  it("should handle checked state changes", () => {
+    const checkedItem: ChecklistItemType = {
+      ...mockItem,
+      checked: true,
+    };
+
+    expect(checkedItem.checked).toBe(true);
+    expect(checkedItem.id).toBe(mockItem.id);
+    expect(checkedItem.content).toBe(mockItem.content);
+  });
+
+  it("should handle order changes for reordering", () => {
+    const reorderedItem: ChecklistItemType = {
+      ...longTextItem,
+      order: 5,
+    };
+
+    expect(reorderedItem.order).toBe(5);
+    expect(reorderedItem.id).toBe(longTextItem.id);
+    expect(reorderedItem.content).toBe(longTextItem.content);
+  });
+
+  it("should handle content updates", () => {
+    const updatedItem: ChecklistItemType = {
+      ...mockItem,
+      content: "Updated content that is longer than the original",
+    };
+
+    expect(updatedItem.content).toBe("Updated content that is longer than the original");
+    expect(updatedItem.id).toBe(mockItem.id);
+    expect(updatedItem.checked).toBe(mockItem.checked);
+    expect(updatedItem.order).toBe(mockItem.order);
+  });
+});

--- a/tests/e2e/add-task-button.spec.ts
+++ b/tests/e2e/add-task-button.spec.ts
@@ -291,7 +291,7 @@ test.describe("Add Task Button", () => {
     await expect(addTaskButton).toBeVisible();
     await addTaskButton.click();
 
-    const newItemInput = page.locator('input[placeholder="Add new item..."]');
+    const newItemInput = page.locator('textarea[placeholder="Add new item..."]');
     await expect(newItemInput).toBeVisible();
     await expect(newItemInput).toBeFocused();
 
@@ -352,7 +352,7 @@ test.describe("Add Task Button", () => {
     await expect(addTaskButton).toBeVisible();
     await addTaskButton.click();
 
-    const newItemInput = page.locator('input[placeholder="Add new item..."]');
+    const newItemInput = page.locator('textarea[placeholder="Add new item..."]');
     await expect(newItemInput).toBeVisible();
     await expect(addTaskButton).toBeVisible();
   });
@@ -439,7 +439,7 @@ test.describe("Add Task Button", () => {
 
     await page.waitForTimeout(500);
 
-    const newItemInput = page.locator('input[placeholder="Add new item..."]');
+    const newItemInput = page.locator('textarea[placeholder="Add new item..."]');
     await expect(newItemInput).not.toBeVisible();
     expect(noteUpdateCalled).toBe(false);
   });

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -120,7 +120,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
     await expect(longTextElement).toBeVisible();
 
     await expect(longTextElement).toHaveClass(/word-wrap/);
-    await expect(longTextElement).toHaveClass(/break-words/);
     await expect(longTextElement).toHaveClass(/whitespace-pre-wrap/);
     await expect(longTextElement).toHaveClass(/overflow-wrap/);
 
@@ -221,7 +220,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
     await expect(textArea).toBeVisible();
 
     await expect(textArea).toHaveClass(/word-wrap/);
-    await expect(textArea).toHaveClass(/break-words/);
     await expect(textArea).toHaveClass(/whitespace-pre-wrap/);
     await expect(textArea).toHaveClass(/overflow-wrap/);
 
@@ -302,7 +300,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
 
     for (const item of [longItem, mediumItem, shortItem]) {
       await expect(item).toHaveClass(/word-wrap/);
-      await expect(item).toHaveClass(/break-words/);
       await expect(item).toHaveClass(/whitespace-pre-wrap/);
       await expect(item).toHaveClass(/overflow-wrap/);
     }

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -1,0 +1,316 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Checklist Item Overflow Behavior", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/auth/session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: {
+            id: "test-user",
+            email: "test@example.com",
+            name: "Test User",
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/user", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "test-user",
+          email: "test@example.com",
+          name: "Test User",
+          isAdmin: true,
+          organization: {
+            id: "test-org",
+            name: "Test Organization",
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/boards/test-board", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          board: {
+            id: "test-board",
+            name: "Test Board",
+            description: "A test board",
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/boards", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          boards: [
+            {
+              id: "test-board",
+              name: "Test Board",
+              description: "A test board",
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/boards/test-board");
+  });
+
+  test("should properly wrap long checklist item content", async ({ page }) => {
+    const longText =
+      "This is an extremely long task description that goes on and on and contains many words to test how our migration handles very long content that might cause issues with database storage or JSON formatting when converted to checklist items and we want to make sure it works correctly without truncation or corruption of the data";
+
+    await page.route("**/api/boards/test-board/notes", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            notes: [
+              {
+                id: "test-note-1",
+                content: "",
+                color: "#fef3c7",
+                archivedAt: null,
+                x: 100,
+                y: 100,
+                width: 250,
+                height: 200,
+                checklistItems: [
+                  {
+                    id: "item-1",
+                    content: longText,
+                    checked: false,
+                    order: 0,
+                  },
+                  {
+                    id: "item-2",
+                    content: "Short item",
+                    checked: false,
+                    order: 1,
+                  },
+                ],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                user: {
+                  id: "test-user",
+                  name: "Test User",
+                  email: "test@example.com",
+                },
+              },
+            ],
+          }),
+        });
+      }
+    });
+
+    await page.waitForSelector("[data-testid='item-1']");
+
+    const longTextElement = page.locator("[data-testid='item-1'] span.flex-1");
+    await expect(longTextElement).toBeVisible();
+
+    await expect(longTextElement).toHaveClass(/word-wrap/);
+    await expect(longTextElement).toHaveClass(/break-words/);
+    await expect(longTextElement).toHaveClass(/whitespace-pre-wrap/);
+    await expect(longTextElement).toHaveClass(/overflow-wrap/);
+
+    const containerElement = page.locator("[data-testid='item-1']");
+    await expect(containerElement).toHaveClass(/items-start/);
+
+    await expect(longTextElement).toContainText(longText);
+
+    const shortTextElement = page.locator("[data-testid='item-2'] span.flex-1");
+    await expect(shortTextElement).toBeVisible();
+    await expect(shortTextElement).toContainText("Short item");
+  });
+
+  test("should handle overflow in edit mode", async ({ page }) => {
+    const longText =
+      "This is an extremely long task description that goes on and on and contains many words to test how our migration handles very long content that might cause issues with database storage or JSON formatting when converted to checklist items and we want to make sure it works correctly without truncation or corruption of the data";
+
+    await page.route("**/api/boards/test-board/notes", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            notes: [
+              {
+                id: "test-note-1",
+                content: "",
+                color: "#fef3c7",
+                archivedAt: null,
+                x: 100,
+                y: 100,
+                width: 250,
+                height: 200,
+                checklistItems: [
+                  {
+                    id: "item-1",
+                    content: "Edit me",
+                    checked: false,
+                    order: 0,
+                  },
+                ],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                user: {
+                  id: "test-user",
+                  name: "Test User",
+                  email: "test@example.com",
+                },
+              },
+            ],
+          }),
+        });
+      }
+    });
+
+    await page.route("**/api/boards/test-board/notes/test-note-1", async (route) => {
+      if (route.request().method() === "PUT") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            note: {
+              id: "test-note-1",
+              content: "",
+              color: "#fef3c7",
+              archivedAt: null,
+              x: 100,
+              y: 100,
+              width: 250,
+              height: 200,
+              checklistItems: [
+                {
+                  id: "item-1",
+                  content: longText,
+                  checked: false,
+                  order: 0,
+                },
+              ],
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              user: {
+                id: "test-user",
+                name: "Test User",
+                email: "test@example.com",
+              },
+            },
+          }),
+        });
+      }
+    });
+
+    await page.waitForSelector("[data-testid='item-1']");
+
+    const checklistItemSpan = page.locator("[data-testid='item-1'] span.flex-1");
+    await checklistItemSpan.click();
+
+    const textArea = page.locator("[data-testid='item-1'] textarea");
+    await expect(textArea).toBeVisible();
+
+    await expect(textArea).toHaveClass(/word-wrap/);
+    await expect(textArea).toHaveClass(/break-words/);
+    await expect(textArea).toHaveClass(/whitespace-pre-wrap/);
+    await expect(textArea).toHaveClass(/overflow-wrap/);
+
+    await textArea.clear();
+    await textArea.fill(longText);
+
+    await page.click("body");
+
+    await expect(checklistItemSpan).toContainText(longText);
+  });
+
+  test("should maintain proper layout with mixed content lengths", async ({ page }) => {
+    const longText =
+      "This is an extremely long task description that goes on and on and contains many words to test how our migration handles very long content that might cause issues with database storage";
+    const mediumText =
+      "This is a medium-length task description that has some words but not too many";
+    const shortText = "Short task";
+
+    await page.route("**/api/boards/test-board/notes", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            notes: [
+              {
+                id: "test-note-1",
+                content: "",
+                color: "#fef3c7",
+                archivedAt: null,
+                x: 100,
+                y: 100,
+                width: 250,
+                height: 300,
+                checklistItems: [
+                  {
+                    id: "item-1",
+                    content: longText,
+                    checked: false,
+                    order: 0,
+                  },
+                  {
+                    id: "item-2",
+                    content: mediumText,
+                    checked: true,
+                    order: 1,
+                  },
+                  {
+                    id: "item-3",
+                    content: shortText,
+                    checked: false,
+                    order: 2,
+                  },
+                ],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                user: {
+                  id: "test-user",
+                  name: "Test User",
+                  email: "test@example.com",
+                },
+              },
+            ],
+          }),
+        });
+      }
+    });
+
+    await page.waitForSelector("[data-testid='item-1']");
+
+    const longItem = page.locator("[data-testid='item-1'] span.flex-1");
+    const mediumItem = page.locator("[data-testid='item-2'] span.flex-1");
+    const shortItem = page.locator("[data-testid='item-3'] span.flex-1");
+
+    await expect(longItem).toBeVisible();
+    await expect(mediumItem).toBeVisible();
+    await expect(shortItem).toBeVisible();
+
+    for (const item of [longItem, mediumItem, shortItem]) {
+      await expect(item).toHaveClass(/word-wrap/);
+      await expect(item).toHaveClass(/break-words/);
+      await expect(item).toHaveClass(/whitespace-pre-wrap/);
+      await expect(item).toHaveClass(/overflow-wrap/);
+    }
+
+    await expect(mediumItem).toHaveClass(/line-through/);
+
+    await expect(longItem).toContainText(longText);
+    await expect(mediumItem).toContainText(mediumText);
+    await expect(shortItem).toContainText(shortText);
+  });
+});

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -125,7 +125,7 @@ test.describe("Checklist Item Overflow Behavior", () => {
     await expect(longTextElement).toHaveClass(/overflow-wrap/);
 
     const containerElement = page.locator("[data-testid='item-1']");
-    await expect(containerElement).toHaveClass(/items-center/);
+    await expect(containerElement).toHaveClass(/items-start/);
 
     await expect(longTextElement).toContainText(longText);
 

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -121,7 +121,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
 
     await expect(longTextElement).toHaveClass(/word-wrap/);
     await expect(longTextElement).toHaveClass(/whitespace-pre-wrap/);
-    await expect(longTextElement).toHaveClass(/overflow-wrap/);
 
     const containerElement = page.locator("[data-testid='item-1']");
     await expect(containerElement).toHaveClass(/items-start/);
@@ -221,7 +220,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
 
     await expect(textArea).toHaveClass(/word-wrap/);
     await expect(textArea).toHaveClass(/whitespace-pre-wrap/);
-    await expect(textArea).toHaveClass(/overflow-wrap/);
 
     await textArea.clear();
     await textArea.fill(longText);
@@ -301,7 +299,6 @@ test.describe("Checklist Item Overflow Behavior", () => {
     for (const item of [longItem, mediumItem, shortItem]) {
       await expect(item).toHaveClass(/word-wrap/);
       await expect(item).toHaveClass(/whitespace-pre-wrap/);
-      await expect(item).toHaveClass(/overflow-wrap/);
     }
 
     await expect(mediumItem).toHaveClass(/line-through/);

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -125,7 +125,7 @@ test.describe("Checklist Item Overflow Behavior", () => {
     await expect(longTextElement).toHaveClass(/overflow-wrap/);
 
     const containerElement = page.locator("[data-testid='item-1']");
-    await expect(containerElement).toHaveClass(/items-start/);
+    await expect(containerElement).toHaveClass(/items-center/);
 
     await expect(longTextElement).toContainText(longText);
 

--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -41,10 +41,11 @@ test.describe("Home Page", () => {
 
     // Test 4: Edit existing checklist item content
     await page.getByText("Gumboard release by Friday").click();
-    const editInput = page.locator('input[value="Gumboard release by Friday"]');
-    await expect(editInput).toBeVisible();
+    await page.waitForTimeout(300);
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toBeVisible({ timeout: 10000 });
     await editInput.fill("Updated Gumboard release deadline");
-    await page.locator('input[value="Updated Gumboard release deadline"]').press("Enter");
+    await editInput.blur();
     await expect(page.getByText("Updated Gumboard release deadline")).toBeVisible();
 
     // Test 5: Delete a checklist item
@@ -63,7 +64,7 @@ test.describe("Home Page", () => {
     // Test 7: Split checklist item (Enter in middle of text)
     const itemToSplit = page.getByText("Helper Tix (Mon-Fri)");
     await itemToSplit.click();
-    const editSplitInput = page.locator('input[value="Helper Tix (Mon-Fri)"]');
+    const editSplitInput = page.locator('textarea[value="Helper Tix (Mon-Fri)"]');
     if (await editSplitInput.isVisible()) {
       await editSplitInput.click();
       await editSplitInput.press("ArrowLeft");

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -265,7 +265,7 @@ test.describe("Note Management", () => {
       const addTaskButton = page.locator('button:has-text("Add task")');
       await expect(addTaskButton).toBeVisible();
       await addTaskButton.click();
-      const newItemInput = page.locator('input[placeholder="Add new item..."]');
+      const newItemInput = page.locator('textarea[placeholder="Add new item..."]');
       await expect(newItemInput).toBeVisible();
       await newItemInput.fill("New test item");
       await newItemInput.press("Enter");
@@ -274,7 +274,7 @@ test.describe("Note Management", () => {
       const existingItem = page.locator("text=Test item").first();
       await expect(existingItem).toBeVisible();
       await existingItem.dblclick();
-      const editInput = page.locator('input[value="Test item"]');
+      const editInput = page.locator('textarea[value="Test item"]');
       await editInput.isVisible();
       await editInput.fill("Edited test item");
       await page.getByText("Note Actual Board").click();
@@ -296,14 +296,14 @@ test.describe("Note Management", () => {
       await page.click('button:has-text("Add Your First Note")');
       await page.waitForTimeout(500);
 
-      const initialInput = page.locator("input.bg-transparent").first();
+      const initialInput = page.locator("textarea.bg-transparent").first();
       await initialInput.fill("First item");
       await initialInput.press("Enter");
       await page.waitForTimeout(300);
 
       await page.click('button:has-text("Add task")');
 
-      const newItemInput = page.locator('input[placeholder="Add new item..."]');
+      const newItemInput = page.locator('textarea[placeholder="Add new item..."]');
       await expect(newItemInput).toBeVisible();
       await expect(newItemInput).toBeFocused();
 
@@ -408,11 +408,11 @@ test.describe("Note Management", () => {
       await expect(page.getByText("#1 Task item")).toBeVisible();
 
       await page.getByText("#1 Task item").click();
-      const editInput = page.locator('input[value="#1 Task item"]');
+      const editInput = page.locator('textarea[value="#1 Task item"]');
       await expect(editInput).toBeVisible();
       await editInput.focus();
       await editInput.fill("#1 Task item edited");
-      await page.locator('input[value="#1 Task item edited"]').press("Enter");
+      await page.locator('textarea[value="#1 Task item edited"]').press("Enter");
       await page.waitForTimeout(500);
       await expect(page.getByText("#1 Task item edited")).toBeVisible();
     });

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -273,9 +273,13 @@ test.describe("Note Management", () => {
       // Test 3: Edit checklist item content
       const existingItem = page.locator("text=Test item").first();
       await expect(existingItem).toBeVisible();
-      await existingItem.dblclick();
-      const editInput = page.locator('textarea[value="Test item"]');
-      await editInput.isVisible();
+      await existingItem.click();
+      await page.waitForTimeout(500);
+      const editInput = page
+        .locator("textarea")
+        .filter({ hasText: "Test item" })
+        .or(page.locator('textarea[value*="Test item"]'));
+      await expect(editInput).toBeVisible();
       await editInput.fill("Edited test item");
       await page.getByText("Note Actual Board").click();
 
@@ -408,11 +412,14 @@ test.describe("Note Management", () => {
       await expect(page.getByText("#1 Task item")).toBeVisible();
 
       await page.getByText("#1 Task item").click();
-      const editInput = page.locator('textarea[value="#1 Task item"]');
+      const editInput = page
+        .locator("textarea")
+        .filter({ hasText: "#1 Task item" })
+        .or(page.locator('textarea[value*="#1 Task item"]'));
       await expect(editInput).toBeVisible();
       await editInput.focus();
       await editInput.fill("#1 Task item edited");
-      await page.locator('textarea[value="#1 Task item edited"]').press("Enter");
+      await editInput.blur();
       await page.waitForTimeout(500);
       await expect(page.getByText("#1 Task item edited")).toBeVisible();
     });


### PR DESCRIPTION
Fixes: #176 
Demo:
[Screencast from 2025-08-13 21-14-14.webm](https://github.com/user-attachments/assets/5278481e-e427-4daa-82a0-99ad93dfc346)


Tests:
<img width="1205" height="873" alt="image" src="https://github.com/user-attachments/assets/3ff4273e-ecf3-45cf-8ec6-428465e53e08" />

Things that I have checked/fixed

- Large checklist items overflow the note
- Maintain the order of the elements (unchecked at the top and checked at the bottom)
- Avoided jankyness while toggling check list items
