### PR TITLE
Fix/boardname filter popover

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1017,6 +1017,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   setSelectedAuthor(authorId);
                   updateURL(undefined, undefined, authorId);
                 }}
+                setshowBoardDropdown={setShowBoardDropdown}
                 className="min-w-fit"
               />
             </div>

--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -75,9 +75,8 @@ function FilterPopover({
       <Button
         onClick={() => {
           setshowBoardDropdown?.(false)
-          if(!disabled) setIsOpen(!isOpen)
-        }}
-          // !disabled && setIsOpen(!isOpen)}
+          !disabled && setIsOpen(!isOpen)
+        }}      
         disabled={disabled}
         className={cn(
           "flex items-center space-x-2 px-3 py-2 text-sm border border-gray-200 dark:border-zinc-800 rounded-md bg-card dark:bg-zinc-900 hover:bg-accent dark:hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-zinc-600 focus:border-transparent transition-colors",

--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -75,7 +75,9 @@ function FilterPopover({
       <Button
         onClick={() => {
           setshowBoardDropdown?.(false)
-          !disabled && setIsOpen(!isOpen)
+          if(!disabled){
+            setIsOpen(!isOpen)
+          }          
         }}      
         disabled={disabled}
         className={cn(

--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -22,7 +22,7 @@ interface FilterPopoverProps {
 
   className?: string;
   disabled?: boolean;
-  setshowBoardDropdown: React.Dispatch<React.SetStateAction<boolean>>;
+  setshowBoardDropdown?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function FilterPopover({
@@ -74,7 +74,7 @@ function FilterPopover({
     <div className={cn("relative", className)} ref={dropdownRef}>
       <Button
         onClick={() => {
-          setshowBoardDropdown(false)
+          setshowBoardDropdown?.(false)
           if(!disabled) setIsOpen(!isOpen)
         }}
           // !disabled && setIsOpen(!isOpen)}

--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -22,6 +22,7 @@ interface FilterPopoverProps {
 
   className?: string;
   disabled?: boolean;
+  setshowBoardDropdown: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function FilterPopover({
@@ -33,6 +34,7 @@ function FilterPopover({
   onAuthorChange,
   className,
   disabled = false,
+  setshowBoardDropdown
 }: FilterPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -71,7 +73,11 @@ function FilterPopover({
   return (
     <div className={cn("relative", className)} ref={dropdownRef}>
       <Button
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onClick={() => {
+          setshowBoardDropdown(false)
+          if(!disabled) setIsOpen(!isOpen)
+        }}
+          // !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
           "flex items-center space-x-2 px-3 py-2 text-sm border border-gray-200 dark:border-zinc-800 rounded-md bg-card dark:bg-zinc-900 hover:bg-accent dark:hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-zinc-600 focus:border-transparent transition-colors",


### PR DESCRIPTION
Clicking Filter dropdown would not close the previously opened Boards dropdown,
allowing both the dropdown to remain visible at once making UI cluttered. Updated the logic so that
opening one automatically closes the other.


https://github.com/user-attachments/assets/7b75d2ce-5359-4bbf-88ff-c6521e990f9d


https://github.com/user-attachments/assets/069e0a55-3346-421e-a6b3-9e057487ab8a




