### PR TITLE
fix: archieve e2e tests

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -474,7 +474,6 @@ export function Note({
                   checked: false,
                   order: 0,
                 }}
-                onEdit={() => handleAddItem()}
                 onDelete={() => {
                   setAddingItem(false);
                   setNewItemContent("");

--- a/tests/e2e/add-task-button.spec.ts
+++ b/tests/e2e/add-task-button.spec.ts
@@ -146,13 +146,13 @@ test.describe("Add Task Button", () => {
     await expect(addTaskButton).toBeVisible();
     await addTaskButton.click();
 
-    const newItemInput = authenticatedPage.locator("textarea");
+    const newItemInput = authenticatedPage.getByTestId("new-item").getByRole("textbox");
     await expect(newItemInput).toBeVisible();
     await expect(newItemInput).toBeFocused();
 
     const newTaskContent = testContext.prefix("New task from button");
+
     await newItemInput.fill(newTaskContent);
-    await newItemInput.press("Enter");
 
     const addItemResponse = authenticatedPage.waitForResponse(
       (resp) =>
@@ -160,6 +160,8 @@ test.describe("Add Task Button", () => {
         resp.request().method() === "PUT" &&
         resp.ok()
     );
+
+    await newItemInput.press("Enter");
     await addItemResponse;
 
     const updatedNote = await testPrisma.note.findUnique({
@@ -220,7 +222,7 @@ test.describe("Add Task Button", () => {
     await expect(addTaskButton).toBeVisible();
     await addTaskButton.click();
 
-    const newItemInput = authenticatedPage.locator("textarea");
+    const newItemInput = authenticatedPage.getByTestId("new-item").getByRole("textbox");
     await expect(newItemInput).toBeVisible();
     await expect(addTaskButton).toBeVisible();
   });
@@ -278,7 +280,7 @@ test.describe("Add Task Button", () => {
       .or(authenticatedPage.locator(".shadow-md").first());
     await noteBackground.click({ position: { x: 50, y: 50 } });
 
-    const newItemInput = authenticatedPage.locator("textarea");
+    const newItemInput = authenticatedPage.getByTestId("new-item");
     await expect(newItemInput).not.toBeVisible();
 
     const finalNote = await testPrisma.note.findUnique({

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -35,21 +35,22 @@ test.describe("Archive Functionality", () => {
       },
     });
 
-    const archivedNote1 = await testPrisma.note.create({
+    await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: new Date(),
         createdBy: testContext.userId,
         boardId: board.id,
-      },
-    });
-
-    await testPrisma.checklistItem.create({
-      data: {
-        content: testContext.prefix("This is an archived note"),
-        checked: false,
-        order: 0,
-        noteId: archivedNote1.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("This is an archived note"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -58,8 +59,9 @@ test.describe("Archive Functionality", () => {
     await authenticatedPage.click('[href="/boards/archive"]');
 
     await expect(authenticatedPage).toHaveURL("/boards/archive");
+
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("This is an archived note")}`)
+      authenticatedPage.getByText(testContext.prefix("This is an archived note"))
     ).toBeVisible();
   });
 
@@ -79,10 +81,20 @@ test.describe("Archive Functionality", () => {
 
     const note = await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: null,
         createdBy: testContext.userId,
         boardId: board.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("Test note to archive"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -98,13 +110,11 @@ test.describe("Archive Functionality", () => {
     await authenticatedPage.goto(`/boards/${board.id}`);
 
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("Test note to archive")}`)
+      authenticatedPage.getByText(testContext.prefix("Test note to archive"))
     ).toBeVisible();
 
-    // Hover over the note to reveal the archive button
-    await authenticatedPage.locator(`text=${testContext.prefix("Test note to archive")}`).hover();
+    await authenticatedPage.getByText(testContext.prefix("Test note to archive")).hover();
 
-    // Find the archive button - it should be visible after hover
     const archiveButton = authenticatedPage.locator('[title="Archive note"]').first();
     await expect(archiveButton).toBeVisible();
     await archiveButton.click();
@@ -122,9 +132,8 @@ test.describe("Archive Functionality", () => {
     });
     expect(archivedNote?.archivedAt).toBeTruthy();
 
-    // Verify note is no longer visible on board
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("Test note to archive")}`)
+      authenticatedPage.getByText(testContext.prefix("Test note to archive"))
     ).not.toBeVisible();
   });
 
@@ -144,10 +153,20 @@ test.describe("Archive Functionality", () => {
 
     const archivedNote2 = await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: new Date(),
         createdBy: testContext.userId,
         boardId: board.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("This is an archived note"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -163,7 +182,7 @@ test.describe("Archive Functionality", () => {
     await authenticatedPage.goto("/boards/archive");
 
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("This is an archived note")}`)
+      authenticatedPage.getByText(testContext.prefix("This is an archived note"))
     ).toBeVisible();
 
     const archiveButton = authenticatedPage.locator('[title="Archive note"]');
@@ -185,13 +204,13 @@ test.describe("Archive Functionality", () => {
 
     await authenticatedPage.goto("/boards/archive");
 
-    await expect(authenticatedPage.locator("text=No notes yet")).toBeVisible();
+    await expect(authenticatedPage.getByText("No notes yet")).toBeVisible();
   });
 
   test('should display board name as "Archive" in navigation', async ({ authenticatedPage }) => {
     await authenticatedPage.goto("/boards/archive");
 
-    await expect(authenticatedPage.locator("text=Archive")).toBeVisible();
+    await expect(authenticatedPage.getByText("Archive")).toBeVisible();
   });
 
   test("should show unarchive button instead of archive button on Archive board", async ({
@@ -210,10 +229,20 @@ test.describe("Archive Functionality", () => {
 
     const archivedNote3 = await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: new Date(),
         createdBy: testContext.userId,
         boardId: board.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("This is an archived note"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -227,8 +256,9 @@ test.describe("Archive Functionality", () => {
     });
 
     await authenticatedPage.goto("/boards/archive");
+
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("This is an archived note")}`)
+      authenticatedPage.getByText(testContext.prefix("This is an archived note"))
     ).toBeVisible();
 
     const unarchiveButton = authenticatedPage.locator('[title="Unarchive note"]');
@@ -254,10 +284,20 @@ test.describe("Archive Functionality", () => {
 
     const archivedNote = await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: new Date(),
         createdBy: testContext.userId,
         boardId: board.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("Test note to unarchive"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -271,8 +311,9 @@ test.describe("Archive Functionality", () => {
     });
 
     await authenticatedPage.goto("/boards/archive");
+
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("Test note to unarchive")}`)
+      authenticatedPage.getByText(testContext.prefix("Test note to unarchive"))
     ).toBeVisible();
 
     const unarchiveButton = authenticatedPage.locator('[title="Unarchive note"]');
@@ -292,9 +333,8 @@ test.describe("Archive Functionality", () => {
     });
     expect(unarchivedNote?.archivedAt).toBe(null);
 
-    // Verify note is no longer visible in archive view
     await expect(
-      authenticatedPage.locator(`text=${testContext.prefix("Test note to unarchive")}`)
+      authenticatedPage.getByText(testContext.prefix("Test note to unarchive"))
     ).not.toBeVisible();
   });
 
@@ -314,10 +354,20 @@ test.describe("Archive Functionality", () => {
 
     const note = await testPrisma.note.create({
       data: {
+        content: "",
         color: "#fef3c7",
         archivedAt: null,
         createdBy: testContext.userId,
         boardId: board.id,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("Note for archive-unarchive workflow test"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
       },
     });
 
@@ -332,9 +382,7 @@ test.describe("Archive Functionality", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
     await expect(
-      authenticatedPage.locator(
-        `text=${testContext.prefix("Note for archive-unarchive workflow test")}`
-      )
+      authenticatedPage.getByText(testContext.prefix("Note for archive-unarchive workflow test"))
     ).toBeVisible();
 
     const archiveButton = authenticatedPage.locator('[title="Archive note"]').first();
@@ -348,11 +396,8 @@ test.describe("Archive Functionality", () => {
     );
     await archiveResponse2;
 
-    // Verify note is no longer visible on board
     await expect(
-      authenticatedPage.locator(
-        `text=${testContext.prefix("Note for archive-unarchive workflow test")}`
-      )
+      authenticatedPage.getByText(testContext.prefix("Note for archive-unarchive workflow test"))
     ).not.toBeVisible();
     const archivedNote = await testPrisma.note.findUnique({
       where: { id: note.id },


### PR DESCRIPTION
This PR fixes 6 tests in file tests/e2e/archive.spec.ts in PR https://github.com/antiwork/gumboard/pull/312

Before:
![Screenshot 2025-08-14 at 1 17 08 AM](https://github.com/user-attachments/assets/f075b0e1-725c-4ca8-8a4e-b8a457ba525a)



After:-
![Screenshot 2025-08-14 at 2 19 04 AM](https://github.com/user-attachments/assets/3098e05b-071e-4553-bc7b-02588e218cff)
