### PR TITLE
fix: board name E2E tests

### DIFF
--- a/tests/e2e/board-name-link.spec.ts
+++ b/tests/e2e/board-name-link.spec.ts
@@ -29,6 +29,7 @@ test.describe("Board Name Link Functionality", () => {
         color: "#fef3c7",
         createdBy: testContext.userId,
         boardId: board1.id,
+        content: "",
       },
     });
 
@@ -46,6 +47,7 @@ test.describe("Board Name Link Functionality", () => {
         color: "#dcfce7",
         createdBy: testContext.userId,
         boardId: board2.id,
+        content: "",
       },
     });
 
@@ -100,6 +102,7 @@ test.describe("Board Name Link Functionality", () => {
         color: "#fef3c7",
         createdBy: testContext.userId,
         boardId: board1.id,
+        content: "",
       },
     });
 
@@ -161,6 +164,7 @@ test.describe("Board Name Link Functionality", () => {
         color: "#fef3c7",
         createdBy: testContext.userId,
         boardId: board.id,
+        content: "",
       },
     });
 


### PR DESCRIPTION
This PR fixes 3 tests in file tests/e2e/board-name-link.spec.ts in PR https://github.com/antiwork/gumboard/pull/312


Before:-

![Screenshot 2025-08-14 at 1 17 08 AM](https://github.com/user-attachments/assets/8a60f264-4e8d-4715-855c-24f909e3e071)



After:-
![Screenshot 2025-08-14 at 2 28 43 AM](https://github.com/user-attachments/assets/1c7b78e3-2cb3-450c-8950-5a3a9d1ec5c1)
