### PR TITLE
feat: add global not-found page and add links to go home to other not found pages + e2e tests

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -926,11 +926,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   if (!board && boardId !== "all-notes" && boardId !== "archive") {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
-        <div className="text-lg">Board not found</div>
-        <Button asChild>
-          <Link href="/">Go to Gumboard home</Link>
-        </Button>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Board not found</h1>
+          <Button asChild>
+            <Link href="/">Go to Gumboard home</Link>
+          </Button>
+        </div>
       </div>
     );
   }

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -930,7 +930,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-2">Board not found</h1>
           <Button asChild>
-            <Link href="/">Go to Gumboard home</Link>
+            <Link href="/">Go to Gumboard</Link>
           </Button>
         </div>
       </div>

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -926,8 +926,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   if (!board && boardId !== "all-notes" && boardId !== "archive") {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
         <div className="text-lg">Board not found</div>
+        <Button asChild>
+          <Link href="/">Go to Gumboard home</Link>
+        </Button>
       </div>
     );
   }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,7 +7,7 @@ export default function NotFound() {
       <div className="text-center">
         <h1 className="text-2xl font-bold mb-2">Page not found</h1>
         <Button asChild>
-          <Link href="/">Go to Gumboard home</Link>
+          <Link href="/">Go to Gumboard</Link>
         </Button>
       </div>
     </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,11 +3,13 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
-      <div className="text-lg">Page not found</div>
-      <Button asChild>
-        <Link href="/">Go to Gumboard home</Link>
-      </Button>
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-2">Page not found</h1>
+        <Button asChild>
+          <Link href="/">Go to Gumboard home</Link>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <div className="text-lg">Page not found</div>
+      <Button asChild>
+        <Link href="/">Go to Gumboard home</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -379,7 +379,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
           </p>
 
           <Button asChild>
-            <Link href="/">Go to Gumboard home</Link>
+            <Link href="/">Go to Gumboard</Link>
           </Button>
         </div>
       </div>

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -377,9 +377,10 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
           <p className="text-muted-foreground mb-4">
             This board doesn&apos;t exist or is not publicly accessible.
           </p>
-          <Link href="/">
-            <Button>Go to Gumboard</Button>
-          </Link>
+
+          <Button asChild>
+            <Link href="/">Go to Gumboard home</Link>
+          </Button>
         </div>
       </div>
     );

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -81,8 +81,8 @@ test.describe("Board Management", () => {
       // Should show the not found message
       await expect(authenticatedPage.locator("text=Board not found")).toBeVisible();
 
-      // Should show the "Go to Gumboard home" button
-      const homeButton = authenticatedPage.getByRole("link", { name: "Go to Gumboard home" });
+      // Should show the "Go to Gumboard" button
+      const homeButton = authenticatedPage.getByRole("link", { name: "Go to Gumboard" });
       await expect(homeButton).toBeVisible();
 
       // Verify the button links to home page
@@ -113,8 +113,8 @@ test.describe("Board Management", () => {
         page.locator("text=This board doesn't exist or is not publicly accessible.")
       ).toBeVisible();
 
-      // Click the "Go to Gumboard home" button
-      const homeButton = page.getByRole("link", { name: "Go to Gumboard home" });
+      // Click the "Go to Gumboard" button
+      const homeButton = page.getByRole("link", { name: "Go to Gumboard" });
       await homeButton.click();
 
       // Wait for navigation to complete

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -71,4 +71,57 @@ test.describe("Board Management", () => {
     await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
     await expect(createButton).toBeEnabled();
   });
+
+  test.describe("Board Not Found", () => {
+    test("should display not found page for invalid board ID", async ({ authenticatedPage }) => {
+      const invalidBoardId = "invalid-board-id";
+
+      await authenticatedPage.goto(`/boards/${invalidBoardId}`);
+
+      // Should show the not found message
+      await expect(authenticatedPage.locator("text=Board not found")).toBeVisible();
+
+      // Should show the "Go to Gumboard home" button
+      const homeButton = authenticatedPage.getByRole("link", { name: "Go to Gumboard home" });
+      await expect(homeButton).toBeVisible();
+
+      // Verify the button links to home page
+      await expect(homeButton).toHaveAttribute("href", "/");
+    });
+
+    test("should not show not found for special board IDs", async ({ authenticatedPage }) => {
+      // Test that special board IDs like "all-notes" and "archive" don't show not found
+      await authenticatedPage.goto("/boards/all-notes");
+
+      // Should not show the not found message
+      await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
+
+      // Navigate to archive
+      await authenticatedPage.goto("/boards/archive");
+
+      // Should not show the not found message
+      await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
+    });
+
+    test("should show not found page for invalid public board", async ({ page }) => {
+      await page.goto(`/public/boards/non-existent-board`);
+
+      // Verify we're on the not found page
+      await expect(page.locator("text=Board not found")).toBeVisible();
+      // Should show the descriptive message for inaccessible boards
+      await expect(
+        page.locator("text=This board doesn't exist or is not publicly accessible.")
+      ).toBeVisible();
+
+      // Click the "Go to Gumboard home" button
+      const homeButton = page.getByRole("link", { name: "Go to Gumboard home" });
+      await homeButton.click();
+
+      // Wait for navigation to complete
+      await page.waitForURL("/");
+
+      // Should navigate to the home page
+      await expect(page).toHaveURL("/");
+    });
+  });
 });

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -5,10 +5,10 @@ test.describe("Not Found Page", () => {
     await page.goto("/this-page-does-not-exist");
 
     await expect(page.locator("text=Page not found")).toBeVisible();
-    await expect(page.getByRole("link", { name: "Go to Gumboard home" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Go to Gumboard" })).toBeVisible();
 
-    // Click the "Go to Gumboard home" button
-    const homeButton = page.getByRole("link", { name: "Go to Gumboard home" });
+    // Click the "Go to Gumboard" button
+    const homeButton = page.getByRole("link", { name: "Go to Gumboard" });
     await homeButton.click();
 
     // Wait for navigation to complete

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Not Found Page", () => {
+  test("should display not found page for invalid routes", async ({ page }) => {
+    await page.goto("/this-page-does-not-exist");
+
+    await expect(page.locator("text=Page not found")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Go to Gumboard home" })).toBeVisible();
+
+    // Click the "Go to Gumboard home" button
+    const homeButton = page.getByRole("link", { name: "Go to Gumboard home" });
+    await homeButton.click();
+
+    // Wait for navigation to complete
+    await page.waitForURL("/");
+
+    // Should navigate to the home page
+    await expect(page).toHaveURL("/");
+  });
+});


### PR DESCRIPTION
fixes #385 
add global not-found page and add links to go home to other not found pages + e2e tests

**before:**

<img width="1440" height="857" alt="image" src="https://github.com/user-attachments/assets/c598c353-d387-455f-8546-9f8baa65f718" />
<img width="1440" height="855" alt="image" src="https://github.com/user-attachments/assets/8413cf83-0188-4ddb-a9fc-a5f49c9b025f" />



**after:**
upd: link text was update to Go to Gumboard everywhere

<img width="1439" height="858" alt="SCR-20250814-bitn" src="https://github.com/user-attachments/assets/39b3e80d-2025-4818-8aed-38f1e9dd45b6" />
<img width="1440" height="856" alt="SCR-20250814-bisk" src="https://github.com/user-attachments/assets/b3077cc0-04f1-473c-8e38-9fce57036833" />
<img width="1440" height="854" alt="SCR-20250814-biuz" src="https://github.com/user-attachments/assets/316248ce-d16a-43e1-afbe-4b8798b9fb51" />
