### PR TITLE
Fix #385: Improve not-found pages with better UX and navigation

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -6,12 +6,13 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { Plus, ChevronDown, Settings, Search, Copy, Trash2 } from "lucide-react";
+import { Plus, ChevronDown, Settings, Search, Copy, Trash2, AlertCircle, Home, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { FullPageLoader } from "@/components/ui/loader";
 import { FilterPopover } from "@/components/ui/filter-popover";
 import { Note as NoteCard } from "@/components/note";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 import {
   AlertDialog,
@@ -896,8 +897,40 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   if (!board && boardId !== "all-notes" && boardId !== "archive") {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-lg">Board not found</div>
+      <div className="min-h-screen flex items-center justify-center bg-background dark:bg-zinc-950 p-4">
+        <Card className="w-full max-w-md bg-white dark:bg-zinc-900 dark:border-zinc-800">
+          <CardHeader className="text-center space-y-4">
+            <div className="mx-auto w-16 h-16 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center">
+              <AlertCircle className="w-8 h-8 text-red-600 dark:text-red-400" />
+            </div>
+            <div>
+              <CardTitle className="text-2xl text-zinc-900 dark:text-zinc-100">
+                Board Not Found
+              </CardTitle>
+              <CardDescription className="text-zinc-600 dark:text-zinc-400 mt-2">
+                This board doesn't exist or you don't have access to it.
+              </CardDescription>
+            </div>
+          </CardHeader>
+          
+          <CardContent className="space-y-4">
+            <div className="flex flex-col space-y-3">
+              <Link href="/dashboard" className="w-full">
+                <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white">
+                  <Home className="w-4 h-4 mr-2" />
+                  View All Boards
+                </Button>
+              </Link>
+              
+              <Link href="/" className="w-full">
+                <Button variant="outline" className="w-full">
+                  <ArrowLeft className="w-4 h-4 mr-2" />
+                  Back to Home
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     );
   }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Home, ArrowLeft, Search } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-zinc-950 dark:to-zinc-900 p-4">
+      <Card className="w-full max-w-md bg-white dark:bg-zinc-900 dark:border-zinc-800">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto w-16 h-16 bg-blue-100 dark:bg-blue-900/20 rounded-full flex items-center justify-center">
+            <Search className="w-8 h-8 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div>
+            <CardTitle className="text-2xl text-zinc-900 dark:text-zinc-100">
+              Page Not Found
+            </CardTitle>
+            <CardDescription className="text-zinc-600 dark:text-zinc-400 mt-2">
+              Sorry, we couldn't find the page you're looking for.
+            </CardDescription>
+          </div>
+        </CardHeader>
+        
+        <CardContent className="space-y-4">
+          <div className="flex flex-col space-y-3">
+            <Link href="/dashboard" className="w-full">
+              <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white">
+                <Home className="w-4 h-4 mr-2" />
+                Go to Dashboard
+              </Button>
+            </Link>
+            
+            <Link href="/" className="w-full">
+              <Button variant="outline" className="w-full">
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Back to Home
+              </Button>
+            </Link>
+          </div>
+          
+          <div className="text-center pt-4 border-t border-gray-200 dark:border-zinc-700">
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Need help? Check our{" "}
+              <Link 
+                href="/dashboard" 
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                boards
+              </Link>{" "}
+              or{" "}
+              <Link 
+                href="/settings" 
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                settings
+              </Link>
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -3,11 +3,12 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Search } from "lucide-react";
+import { Search, AlertCircle, Home, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { FullPageLoader } from "@/components/ui/loader";
 import { FilterPopover } from "@/components/ui/filter-popover";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Note, Board } from "@/components/note";
 
 export default function PublicBoardPage({ params }: { params: Promise<{ id: string }> }) {
@@ -351,16 +352,38 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
 
   if (!board) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Board not found</h1>
-          <p className="text-muted-foreground mb-4">
-            This board doesn&apos;t exist or is not publicly accessible.
-          </p>
-          <Link href="/">
-            <Button>Go to Gumboard</Button>
-          </Link>
-        </div>
+      <div className="min-h-screen flex items-center justify-center bg-background dark:bg-zinc-950 p-4">
+        <Card className="w-full max-w-md bg-white dark:bg-zinc-900 dark:border-zinc-800">
+          <CardHeader className="text-center space-y-4">
+            <div className="mx-auto w-16 h-16 bg-orange-100 dark:bg-orange-900/20 rounded-full flex items-center justify-center">
+              <AlertCircle className="w-8 h-8 text-orange-600 dark:text-orange-400" />
+            </div>
+            <div>
+              <CardTitle className="text-2xl text-zinc-900 dark:text-zinc-100">
+                Board Not Found
+              </CardTitle>
+              <CardDescription className="text-zinc-600 dark:text-zinc-400 mt-2">
+                This board doesn't exist or is not publicly accessible.
+              </CardDescription>
+            </div>
+          </CardHeader>
+          
+          <CardContent className="space-y-4">
+            <div className="flex flex-col space-y-3">
+              <Link href="/" className="w-full">
+                <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white">
+                  <Home className="w-4 h-4 mr-2" />
+                  Go to Gumboard
+                </Button>
+              </Link>
+              
+              <Button variant="outline" className="w-full" onClick={() => window.history.back()}>
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Go Back
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     );
   }


### PR DESCRIPTION
Fixes #385

Saw the not-found pages needed some love, so I cleaned them up!

What I fixed
- Added a proper 404 page (was missing entirely)  
- Made the "Board not found" pages actually helpful instead of just text
- Added navigation buttons so people aren't stuck on dead-end pages
- Made everything look consistent with the rest of the app

The pages now use the same Card design system as the rest of the app, with proper icons, navigation buttons, and support for both light/dark themes.

Happy to make any adjustments if needed!