### PR TITLE
perf: Replace O(n) org membership checks with O(1) lookups + add index 

### DIFF
--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -162,30 +162,24 @@ export async function DELETE(
     // Check if board exists and user has access
     const board = await db.board.findUnique({
       where: { id: boardId },
-      include: {
-        organization: {
-          include: {
-            members: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-                isAdmin: true,
-              },
-            },
-          },
-        },
-      },
+      include: { organization: true },
     });
 
     if (!board) {
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
 
-    // Check if user is member of the organization
-    const currentUser = board.organization.members.find(
-      (member) => member.id === session?.user?.id
-    );
+    // Check if user is member of the organization and get admin status
+    const currentUser = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    });
 
     if (!currentUser) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });

--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const board = await db.board.findUnique({
       where: { id: boardId },
-      include: { organization: { include: { members: true } } },
+      include: { organization: true },
     });
 
     if (!board) {
@@ -34,9 +34,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // Check if user is member of the organization
-    const isMember = board.organization.members.some((member) => member.id === session?.user?.id);
+    const userInOrg = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+    });
 
-    if (!isMember) {
+    if (!userInOrg) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 

--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -77,28 +77,24 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     // Check if board exists and user has access
     const board = await db.board.findUnique({
       where: { id: boardId },
-      include: {
-        organization: {
-          include: {
-            members: {
-              select: {
-                id: true,
-                isAdmin: true,
-              },
-            },
-          },
-        },
-      },
+      include: { organization: true },
     });
 
     if (!board) {
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
 
-    // Check if user is member of the organization
-    const currentUser = board.organization.members.find(
-      (member) => member.id === session?.user?.id
-    );
+    // Check if user is member of the organization and get admin status
+    const currentUser = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    });
 
     if (!currentUser) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });

--- a/prisma/migrations/20250814172001_add_user_org_index/migration.sql
+++ b/prisma/migrations/20250814172001_add_user_org_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "idx_user_org" ON "users"("organizationId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,6 @@ model User {
   notes          Note[]
 
   @@index([organizationId], name: "idx_user_org")
-  @@index([organizationId, isAdmin], name: "idx_user_org_admin")
   @@map("users")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,8 @@ model User {
   createdSelfServeInvites OrganizationSelfServeInvite[]
   notes          Note[]
 
+  @@index([organizationId], name: "idx_user_org")
+  @@index([organizationId, isAdmin], name: "idx_user_org_admin")
   @@map("users")
 }
 


### PR DESCRIPTION
## Problem

Board API routes were fetching entire organization member lists to check if a single user has access. These **O(n)** operations occur on every board interaction - viewing boards, creating/editing notes, updating settings - making them extremely frequent hot paths that degrade performance as organizations grow.

## Inefficient lookups found

* `app/api/boards/[id]/route.ts:12` - **GET** loads all members, uses only one for membership check
* `app/api/boards/[id]/route.ts:78-89` - **PUT** loads all members, uses only one for admin check
* `app/api/boards/[id]/route.ts:163-179` - **DELETE** loads all members (including names/emails) unnecessarily
* `app/api/boards/[id]/public/route.ts:17-31` - **PUT** loads all members for single-user verification

## Solution

* Replaced `include: { members: true }` with direct database queries using `WHERE` clauses to fetch only the specific user–organization relationship needed for authorization.
* Added database index on `User.organizationId` to optimize lookups. Since queries filter by the primary key `id` first, this single index is sufficient to make membership checks constant-time regardless of organization size.

## Impact

Mainly our performance won't degrade as org member size grows.
- Performance remains constant as org scale grows ( O(1) instead of O(N)
- Dramatically reduces network payload per request: instead of transferring all member records (IDs, names, emails, admin flags), we now fetch only the single user record needed for authorization. I ran a test testing data over network simulating the main branch code and current branch code and their is ~95% reduction for n = 100 members in an org in data transfer
- I ran a benchmark for n = 100 users in a org against db and the code is 3.5x faster per query
- These optimisations apply to every board. Overall should make / keep the app responsive as it grows