### PR TITLE
fix: archieve spec

### DIFF
--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -184,7 +184,8 @@ test.describe("Archive Functionality", () => {
 
     await authenticatedPage.goto("/boards/archive");
 
-    await expect(authenticatedPage.locator('button:has-text("Add Note")')).toBeVisible();
+    const deleteNoteButtons = authenticatedPage.getByRole("button", { name: /Delete Note/ });
+    await expect(deleteNoteButtons).toHaveCount(0);
   });
 
   test('should display board name as "Archive" in navigation', async ({ authenticatedPage }) => {

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -184,7 +184,7 @@ test.describe("Archive Functionality", () => {
 
     await authenticatedPage.goto("/boards/archive");
 
-    await expect(authenticatedPage.getByText("No notes yet")).toBeVisible();
+    await expect(authenticatedPage.locator('button:has-text("Add Note")')).toBeVisible();
   });
 
   test('should display board name as "Archive" in navigation', async ({ authenticatedPage }) => {


### PR DESCRIPTION
This PR fixes E2E tests in https://github.com/antiwork/gumboard/pull/312

After:-

![Screenshot 2025-08-14 at 9 26 19 PM](https://github.com/user-attachments/assets/ecc3a753-f2a2-4625-910f-3626118011b6)
