### PR TITLE
[Refactor] Use middleware for DRY

### DIFF
--- a/app/api/auth/check/route.ts
+++ b/app/api/auth/check/route.ts
@@ -1,0 +1,28 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+
+/**
+ * Lightweight auth check endpoint for middleware
+ * Only validates session without database calls
+ */
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ authenticated: false }, { status: 401 });
+    }
+
+    return NextResponse.json({
+      authenticated: true,
+      user: {
+        id: session.user.id,
+        email: session.user.email,
+        name: session.user.name,
+      },
+    });
+  } catch (error) {
+    console.error("Auth check error:", error);
+    return NextResponse.json({ authenticated: false }, { status: 500 });
+  }
+}

--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import {
   updateSlackMessage,
@@ -7,6 +6,7 @@ import {
   hasValidContent,
   shouldSendNotification,
 } from "@/lib/slack";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 
 // Update a note
 export async function PUT(
@@ -14,10 +14,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string; noteId: string }> }
 ) {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { color, archivedAt, checklistItems } = await request.json();
     const { id: boardId, noteId } = await params;
@@ -259,10 +256,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; noteId: string }> }
 ) {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { id: boardId, noteId } = await params;
 

--- a/app/api/boards/[id]/public/route.ts
+++ b/app/api/boards/[id]/public/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { isPublic } = await request.json();
     const boardId = (await params).id;

--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -1,10 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth();
+    const session = await getAuthenticatedSession();
     const boardId = (await params).id;
 
     const board = await db.board.findUnique({
@@ -27,10 +27,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           },
         },
       });
-    }
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // Check if user is member of the organization
@@ -65,11 +61,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const boardId = (await params).id;
     const { name, description, isPublic, sendSlackUpdates } = await request.json();
@@ -151,11 +143,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const boardId = (await params).id;
 

--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -1,16 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { NOTE_COLORS } from "@/lib/constants";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 
 // Get all notes from all boards in the organization
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function GET(request: NextRequest) {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     // Get user with organization
     const user = await db.user.findUnique({
@@ -63,10 +60,7 @@ export async function GET(request: NextRequest) {
 // Create a new note (for global view, we need to specify which board)
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { color, boardId, checklistItems } = await request.json();
 

--- a/app/api/boards/archive/notes/route.ts
+++ b/app/api/boards/archive/notes/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 
 export async function GET() {
   try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const user = await db.user.findUnique({
       where: { id: session.user.id },

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const user = await db.user.findUnique({
       where: { id: session.user.id },
@@ -54,11 +50,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { name, description, isPublic } = await request.json();
 

--- a/app/api/organization/invite/route.ts
+++ b/app/api/organization/invite/route.ts
@@ -1,19 +1,15 @@
-import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { env } from "@/lib/env";
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { getBaseUrl } from "@/lib/utils";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 
 const resend = new Resend(env.AUTH_RESEND_KEY);
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { email } = await request.json();
 

--- a/app/api/organization/invites/[id]/route.ts
+++ b/app/api/organization/invites/[id]/route.ts
@@ -1,4 +1,4 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -7,11 +7,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const inviteId = (await params).id;
 

--- a/app/api/organization/invites/route.ts
+++ b/app/api/organization/invites/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     // Get user with organization
     const user = await db.user.findUnique({

--- a/app/api/organization/members/[id]/route.ts
+++ b/app/api/organization/members/[id]/route.ts
@@ -1,15 +1,11 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 // Update member (toggle admin role)
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { isAdmin } = await request.json();
     const memberId = (await params).id;
@@ -62,11 +58,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const memberId = (await params).id;
 

--- a/app/api/organization/route.ts
+++ b/app/api/organization/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(request: NextRequest) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { name, slackWebhookUrl } = await request.json();
 

--- a/app/api/organization/self-serve-invites/[id]/route.ts
+++ b/app/api/organization/self-serve-invites/[id]/route.ts
@@ -1,4 +1,4 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -7,11 +7,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const inviteId = (await params).id;
 

--- a/app/api/organization/self-serve-invites/route.ts
+++ b/app/api/organization/self-serve-invites/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 import { nanoid } from "nanoid";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 
 // Generate a cryptographically secure token using nanoid
 function generateSecureToken(): string {
@@ -11,11 +11,7 @@ function generateSecureToken(): string {
 // Get all active self-serve invites for the organization
 export async function GET() {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     // Get user with organization
     const user = await db.user.findUnique({
@@ -54,11 +50,7 @@ export async function GET() {
 // Create a new self-serve invite
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { name, expiresAt, usageLimit } = await request.json();
 

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(request: NextRequest) {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const { name } = await request.json();
 

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,14 +1,10 @@
-import { auth } from "@/auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     // Get user with organization and members
     const user = await db.user.findUnique({

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -53,11 +53,7 @@ export async function GET() {
 
 export async function DELETE() {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await getAuthenticatedSession();
 
     const userId = session.user.id;
 

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -1,0 +1,19 @@
+import { auth } from "@/auth";
+import type { Session } from "next-auth";
+import { DeepRequired } from "utility-types";
+
+export type AuthenticatedSession = DeepRequired<Session>;
+/**
+ * Get authenticated session - only use in middleware-protected routes
+ * where we know authentication has already been verified
+ */
+export async function getAuthenticatedSession(): Promise<AuthenticatedSession> {
+  const session = await auth();
+
+  // This should never happen in middleware-protected routes
+  if (!session?.user?.id) {
+    throw new Error("Authentication required - this should not happen in protected routes");
+  }
+
+  return session as AuthenticatedSession;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  try {
+    // NOTE: We can't call prisma client here so calling this endpoint
+    // is a workaround.
+    const authCheckUrl = new URL("/api/auth/check", request.url);
+    const authResponse = await fetch(authCheckUrl.toString(), {
+      headers: {
+        // Forward cookies to maintain session
+        cookie: request.headers.get("cookie") || "",
+      },
+    });
+
+    if (!authResponse.ok) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // User is authenticated, continue with the request
+    return NextResponse.next();
+  } catch (error) {
+    console.error("Middleware auth check failed:", error);
+    return NextResponse.json({ error: "Authentication failed" }, { status: 500 });
+  }
+}
+
+export const config = {
+  matcher: ["/api/boards/:path*", "/api/organization/:path*", "/api/user/:path*"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "server-only": "^0.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
+        "utility-types": "^3.11.0",
         "zod": "^3.25.67"
       },
       "devDependencies": {
@@ -12067,6 +12068,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
+    "utility-types": "^3.11.0",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -125,3 +125,26 @@ test.describe("Board Management", () => {
     });
   });
 });
+
+test.describe("Authentication", () => {
+  test.describe("Protected API Routes", () => {
+    test("should block unauthenticated requests to /api/boards", async ({ page }) => {
+      // Make direct API calls without authentication
+      const response = await page.request.get("/api/boards");
+
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body).toEqual({ error: "Unauthorized" });
+    });
+
+    test("should allow authenticated requests to /api/boards", async ({ authenticatedPage }) => {
+      // This should succeed because authenticatedPage has valid session
+      const response = await authenticatedPage.request.get("/api/boards");
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveProperty("boards");
+      expect(Array.isArray(body.boards)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/middleware.spec.ts
+++ b/tests/unit/middleware.spec.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { middleware } from "../../middleware";
+
+// Mock NextResponse
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: jest.fn(),
+    next: jest.fn(),
+  },
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+const mockedFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+// Mock console.error to avoid noise in test output
+const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+describe("Middleware", () => {
+  let mockRequest: NextRequest;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create a mock NextRequest
+    mockRequest = {
+      url: "https://example.com/api/boards/123",
+      headers: new Map([["cookie", "session=test-session"]]),
+    } as unknown as NextRequest;
+
+    // Reset NextResponse mocks
+    (NextResponse.json as jest.Mock).mockReturnValue("json-response");
+    (NextResponse.next as jest.Mock).mockReturnValue("next-response");
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe("Successful authentication", () => {
+    it("should continue with the request when user is authenticated", async () => {
+      // Mock successful auth response
+      mockedFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          authenticated: true,
+          user: { id: "user-1", email: "test@example.com" },
+        }),
+      } as Response);
+
+      const result = await middleware(mockRequest);
+
+      expect(mockedFetch).toHaveBeenCalledWith("https://example.com/api/auth/check", {
+        headers: {
+          cookie: "session=test-session",
+        },
+      });
+
+      expect(NextResponse.next).toHaveBeenCalled();
+      expect(result).toBe("next-response");
+    });
+
+    it("should handle requests without cookies", async () => {
+      // Mock request without cookies
+      const requestWithoutCookies = {
+        url: "https://example.com/api/user/profile",
+        headers: new Map(),
+      } as unknown as NextRequest;
+
+      mockedFetch.mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      await middleware(requestWithoutCookies);
+
+      expect(mockedFetch).toHaveBeenCalledWith("https://example.com/api/auth/check", {
+        headers: {
+          cookie: "",
+        },
+      });
+    });
+  });
+
+  describe("Failed authentication", () => {
+    it("should return 401 when auth check returns not ok", async () => {
+      mockedFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      } as Response);
+
+      const result = await middleware(mockRequest);
+
+      expect(NextResponse.json).toHaveBeenCalledWith({ error: "Unauthorized" }, { status: 401 });
+      expect(NextResponse.next).not.toHaveBeenCalled();
+      expect(result).toBe("json-response");
+    });
+  });
+});


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumboard/issues/397

We have been copying this snippet over and over in all routes:
```tsx
    if (!session?.user?.id) {
      return NextResponse.json({ authenticated: false }, { status: 401 });
    }
```

we could move it to a middleware for DRY