### PR TITLE
refactor: remove unnecessary "use client" directives to reduce client bundle size

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
-import { Toaster } from "@/components/ui/sonner";
+import Toaster from "@/components/ui/sonner";
 import { UserProvider } from "./contexts/UserContext";
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,4 +1,3 @@
-
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,9 +1,11 @@
-import { useTheme } from "next-themes";
+"use client";
+
 import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { useTheme } from "next-themes";
 
 const Toaster = (props: ToasterProps) => {
   const { theme = "system" } = useTheme();
   return <Sonner theme={theme as ToasterProps["theme"]} {...props} />;
 };
 
-export { Toaster };
+export default Toaster;

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";


### PR DESCRIPTION
### Summary
Removed `"use client"` directives from components and pages that do not require client-side rendering. This reduces the client bundle size, improves maintainability, and makes the server/client boundary clearer.

### Changes
- Audited all files with `"use client"` in `app/` and `components/`
- Kept `"use client"` only where necessary:
  - React hooks are used (`useState`, `useEffect`, etc.)
  - Browser APIs are accessed (`window`, `document`, `localStorage`, etc.)
  - Required by Next.js (e.g., error boundaries)
- Removed it from files safe to render as server components

### Why
- **Performance**: Smaller client-side JavaScript footprint
- **Clarity**: Clearer separation of server vs client components
- **Maintainability**: Easier to reason about rendering requirements

### Impact
- Reduced number of client components
- Leaner production build
- No change in app behavior

### Verification
- Ran `npm run lint` → ✅
- Ran `npm test` → ✅
- Verified `npm run dev` works and all affected pages/components behave the same
- Build works locally after resolving unrelated migration issue

---

Closes #397
