### PR TITLE
fix: profile icon not showing correctly when creating notes or adding tasks

### DIFF
--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -177,7 +177,7 @@ export async function PUT(
           ...(archivedAt !== undefined && { archivedAt }),
         },
         include: {
-          user: { select: { id: true, name: true, email: true } },
+          user: { select: { id: true, name: true, email: true, image: true } },
           board: { select: { name: true, sendSlackUpdates: true } },
           checklistItems: { orderBy: { order: "asc" } },
         },

--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -167,6 +167,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
             id: true,
             name: true,
             email: true,
+            image: true,
           },
         },
         checklistItems: { orderBy: { order: "asc" } },

--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -132,6 +132,7 @@ export async function POST(request: NextRequest) {
             id: true,
             name: true,
             email: true,
+            image: true,
           },
         },
         board: {


### PR DESCRIPTION
Fix: Incorrect Profile Icon in Notes When Creating or Updating Tasks

**Issue**
- When creating a note, the profile icon didn’t use the current user’s profile picture.
- When adding tasks to a note, the profile icon changed to initials instead of keeping the correct image.
- The backend didn’t return the image field for user, causing the UI to fall back to initials.

**Changes**
- Updated include.user selection to also return image.
- Ensure user data includes image when creating and updating notes.
- Preserve original user data when adding tasks to notes.

**Result**
Notes now consistently display the correct profile picture for the current user in all cases.


**Before**

https://github.com/user-attachments/assets/c56428bb-dfe0-4159-ada1-f0f4b910fde1



**After**

https://github.com/user-attachments/assets/f70e0501-8b64-4095-8658-d4480da33ec1




Fixes https://github.com/antiwork/gumboard/issues/411