### PR TITLE
fix: 'Delete Board' and 'Save settings' button color

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,9 +9,9 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-blue-600 text-white hover:bg-blue-700",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 dark:text-white",
         outline:
           "border border-zinc-100 dark:border-zinc-700 bg-background hover:bg-sky-600 hover:border-sky-600 hover:text-white dark:bg-input/30 dark:border-zinc-800 dark:hover:bg-sky-600 dark:hover:text-white dark:text-white",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",


### PR DESCRIPTION
Fix: "Delete Board" button missing in light mode and "Save settings" missing in dark mode

**Issue**
- Dark mode: "Save settings" button text was invisible due to invalid text color.
- Light mode: "Delete Board" button text was invisible due to invalid text color.
- The default button variant didn’t use `bg-blue-600` like other buttons in the codebase.

**Changes**
- Updated default button variant to use `bg-blue-600` and `bg-blue-700` on hover to match other buttons.
- Updated destructive button variant to use correct text colors in both light and dark modes.

**Result**
- "Save settings" button now uses the same blue style as other buttons.
- "Delete Board" button text is now visible in both light and dark modes.


**Before**
| Dark | Light |
|---------|---------|
| <img width="554" height="521" alt="image" src="https://github.com/user-attachments/assets/5cb08bb5-3a11-4818-a191-b13a456f0a28" /> | <img width="534" height="501" alt="image" src="https://github.com/user-attachments/assets/b643b83e-7ef4-4545-a206-df1638c6c668" /> |

**After**

| Dark | Light |
|---------|---------|
| <img width="540" height="505" alt="image" src="https://github.com/user-attachments/assets/cc5138af-1edd-42d9-83a8-25ba4f7845c1" /> | <img width="535" height="499" alt="image" src="https://github.com/user-attachments/assets/36514351-8dda-44e4-9623-db0c2b804baa" /> |

Fixes https://github.com/antiwork/gumboard/issues/411