### PR TITLE
Fix: exclude archived notes from the boards query

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -37,6 +37,7 @@ export async function GET() {
             notes: {
               where: {
                 deletedAt: null,
+                archivedAt: null,
               },
             },
           },


### PR DESCRIPTION
**Fix:** 
exclude archived notes from the boards query

**Issue:**
The GET endpoint for boards is returning notes that have been archived. 
Which shows inaccurate counts of notes on the board.

**Solution:**
- Added an "archivedAt: null" condition to the board query where clause

<img width="383" height="163" alt="Screenshot 2025-08-15 at 17 11 35" src="https://github.com/user-attachments/assets/1b0a1261-b77c-44a8-b8f7-169a58a6cd03" />
