### PR TITLE
feat: add GripVertical icon to checklist item for improved UI

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Trash2 } from "lucide-react";
+import { Trash2, GripVertical } from "lucide-react";
 
 export interface ChecklistItem {
   id: string;
@@ -107,6 +107,7 @@ export function ChecklistItem({
       data-testid={process.env.NODE_ENV !== "production" ? item.id : undefined}
       data-testorder={process.env.NODE_ENV !== "production" ? item.order : undefined}
     >
+      <GripVertical className="cursor-grabbing text-zinc-200 dark:text-zinc-700 mt-1.5 h-4 w-4 opacity-0 group-hover/item:opacity-100" />
       <Checkbox
         checked={item.checked}
         onCheckedChange={() => !readonly && onToggle?.(item.id)}
@@ -119,7 +120,7 @@ export function ChecklistItem({
         value={editContent ?? item.content}
         onChange={(e) => onEditContentChange?.(e.target.value)}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 resize-none overflow-hidden outline-none",
+          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}


### PR DESCRIPTION
Comes under #411 
- This PR adds a Grip holder for re-ordering the checklist items.

## Demo
### Before

https://github.com/user-attachments/assets/8bb127fc-e109-4388-a2ea-f1b467005360

### After


https://github.com/user-attachments/assets/fffc6a86-be84-4b0a-9c61-afbc80b497b6



