### PR TITLE
feat: add delete_user functionality with E2E tests

### DIFF
--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -53,7 +53,7 @@ export async function GET() {
     console.error("Error fetching user:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-} 
+}
 
 export async function DELETE() {
   try {
@@ -76,4 +76,4 @@ export async function DELETE() {
     console.error("Error deleting user:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-} 
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -8,15 +8,17 @@ import { Label } from "@/components/ui/label";
 import { Mail, Trash2, AlertTriangle } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
 
-import { AlertDialog, 
+import {
+  AlertDialog,
   AlertDialogAction,
-   AlertDialogCancel,
-    AlertDialogContent,
-     AlertDialogDescription, 
-     AlertDialogFooter,
-      AlertDialogHeader,
-       AlertDialogTitle,
-        AlertDialogTrigger } from "@/components/ui/alert-dialog";
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { useUser } from "@/app/contexts/UserContext";
 import { useRouter } from "next/navigation";
 
@@ -54,7 +56,6 @@ export default function ProfileSettingsPage() {
       setDeleting(false);
     }
   };
-
 
   const handleSaveProfile = async () => {
     setSaving(true);
@@ -152,9 +153,12 @@ export default function ProfileSettingsPage() {
                 <AlertTriangle className="w-5 h-5" />
               </div>
               <div className="flex-1">
-                <h3 className="text-sm font-semibold text-red-700 dark:text-red-400">Danger zone</h3>
+                <h3 className="text-sm font-semibold text-red-700 dark:text-red-400">
+                  Danger zone
+                </h3>
                 <p className="text-sm text-red-700/80 dark:text-red-300/80">
-                  Deleting your account will remove you from your organization and delete content you created that is owned by you. This action cannot be undone.
+                  Deleting your account will remove you from your organization and delete content
+                  you created that is owned by you. This action cannot be undone.
                 </p>
                 <div className="mt-4">
                   <AlertDialog>
@@ -171,16 +175,25 @@ export default function ProfileSettingsPage() {
                           Delete account?
                         </AlertDialogTitle>
                         <AlertDialogDescription className="text-foreground dark:text-zinc-100">
-                          This will permanently delete your account and related data. This action cannot be undone.
+                          This will permanently delete your account and related data. This action
+                          cannot be undone.
                           <ul className="list-disc pl-5 mt-2 text-sm">
                             <li>You will be signed out immediately.</li>
                             <li>Your personal profile will be removed.</li>
-                            <li>Notes and content owned by you may be deleted or reassigned, depending on organization settings.</li>
+                            <li>
+                              Notes and content owned by you may be deleted or reassigned, depending
+                              on organization settings.
+                            </li>
                           </ul>
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
-                        <AlertDialogCancel disabled={deleting} className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800">Cancel</AlertDialogCancel>
+                        <AlertDialogCancel
+                          disabled={deleting}
+                          className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        >
+                          Cancel
+                        </AlertDialogCancel>
                         <AlertDialogAction
                           className="bg-red-600 hover:bg-red-700 text-white"
                           onClick={handleDeleteAccount}

--- a/tests/e2e/delete-user.spec.ts
+++ b/tests/e2e/delete-user.spec.ts
@@ -6,18 +6,15 @@ test.describe("Delete User Functionality", () => {
     testContext,
     testPrisma,
   }) => {
-  
     await authenticatedPage.goto("/settings");
 
-    
     await expect(authenticatedPage.locator("text=Profile Settings")).toBeVisible();
-    
-    
+
     await expect(authenticatedPage.locator("text=Danger zone")).toBeVisible();
 
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await expect(deleteButton).toBeVisible();
-    
+
     await expect(deleteButton.locator("svg")).toBeVisible();
   });
 
@@ -28,17 +25,14 @@ test.describe("Delete User Functionality", () => {
   }) => {
     await authenticatedPage.goto("/settings");
 
-
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await deleteButton.click();
 
-
     await expect(authenticatedPage.locator("text=Delete account?")).toBeVisible();
-    
+
     await expect(
       authenticatedPage.locator("text=This will permanently delete your account and related data")
     ).toBeVisible();
-    
 
     await expect(
       authenticatedPage.locator("text=You will be signed out immediately")
@@ -46,7 +40,6 @@ test.describe("Delete User Functionality", () => {
     await expect(
       authenticatedPage.locator("text=Your personal profile will be removed")
     ).toBeVisible();
-    
 
     await expect(authenticatedPage.locator('button:has-text("Cancel")')).toBeVisible();
     await expect(authenticatedPage.locator('button:has-text("Yes, delete")')).toBeVisible();
@@ -59,20 +52,15 @@ test.describe("Delete User Functionality", () => {
   }) => {
     await authenticatedPage.goto("/settings");
 
-
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await deleteButton.click();
 
-
     await expect(authenticatedPage.locator("text=Delete account?")).toBeVisible();
-
 
     const cancelButton = authenticatedPage.locator('button:has-text("Cancel")');
     await cancelButton.click();
 
-
     await expect(authenticatedPage.locator("text=Delete account?")).not.toBeVisible();
-    
 
     const user = await testPrisma.user.findUnique({
       where: { id: testContext.userId },
@@ -86,7 +74,6 @@ test.describe("Delete User Functionality", () => {
     testContext,
     testPrisma,
   }) => {
-    
     const board = await testPrisma.board.create({
       data: {
         name: testContext.getBoardName("Test Board"),
@@ -113,7 +100,6 @@ test.describe("Delete User Functionality", () => {
       },
     });
 
-
     await testPrisma.organizationInvite.create({
       data: {
         email: "invite@example.com",
@@ -121,7 +107,6 @@ test.describe("Delete User Functionality", () => {
         invitedBy: testContext.userId,
       },
     });
-
 
     await testPrisma.organizationSelfServeInvite.create({
       data: {
@@ -133,7 +118,6 @@ test.describe("Delete User Functionality", () => {
       },
     });
 
-
     const userBeforeDeletion = await testPrisma.user.findUnique({
       where: { id: testContext.userId },
     });
@@ -141,39 +125,33 @@ test.describe("Delete User Functionality", () => {
 
     await authenticatedPage.goto("/settings");
 
-
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await deleteButton.click();
 
-
     const confirmButton = authenticatedPage.locator('button:has-text("Yes, delete")');
-    
+
     const deleteResponse = authenticatedPage.waitForResponse(
       (resp) =>
-        resp.url().includes("/api/user") &&
-        resp.request().method() === "DELETE" &&
-        resp.ok()
+        resp.url().includes("/api/user") && resp.request().method() === "DELETE" && resp.ok()
     );
 
-        await confirmButton.click();
+    await confirmButton.click();
     await deleteResponse;
 
     // Should redirect to home page after successful deletion
     await expect(authenticatedPage).toHaveURL(/^\/$|.*localhost:3000\/$/, { timeout: 10000 });
-
 
     const userAfterDeletion = await testPrisma.user.findUnique({
       where: { id: testContext.userId },
     });
     expect(userAfterDeletion).toBeNull();
 
-
     const sessionAfterDeletion = await testPrisma.session.findFirst({
       where: { userId: testContext.userId },
     });
     expect(sessionAfterDeletion).toBeNull();
 
-        // Verify organization invites created by user are deleted
+    // Verify organization invites created by user are deleted
     const invitesAfterDeletion = await testPrisma.organizationInvite.findMany({
       where: { invitedBy: testContext.userId },
     });
@@ -183,7 +161,6 @@ test.describe("Delete User Functionality", () => {
       where: { createdBy: testContext.userId },
     });
     expect(selfServeInvitesAfterDeletion).toHaveLength(0);
-
 
     const boardAfterDeletion = await testPrisma.board.findUnique({
       where: { id: board.id },
@@ -203,7 +180,7 @@ test.describe("Delete User Functionality", () => {
   }) => {
     await authenticatedPage.route("**/api/user", async (route) => {
       if (route.request().method() === "DELETE") {
-        await new Promise(resolve => setTimeout(resolve, 2000)); // Reduced from 3000 to 2000
+        await new Promise((resolve) => setTimeout(resolve, 2000)); // Reduced from 3000 to 2000
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -216,21 +193,21 @@ test.describe("Delete User Functionality", () => {
 
     await authenticatedPage.goto("/settings");
 
-    
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await deleteButton.click();
 
     const confirmButton = authenticatedPage.locator('button:has-text("Yes, delete")');
-    
-    
+
     await confirmButton.click();
 
     // Check loading state appears
-    await expect(authenticatedPage.locator('button:has-text("Deleting...")')).toBeVisible({ timeout: 1000 });
-    
+    await expect(authenticatedPage.locator('button:has-text("Deleting...")')).toBeVisible({
+      timeout: 1000,
+    });
+
     const loadingButton = authenticatedPage.locator('button:has-text("Deleting...")');
     await expect(loadingButton).toBeDisabled();
-    
+
     // Wait for the loading to complete - this should redirect
     // Due to the mock, we might not get the full deletion flow, so just verify loading state works
     // The redirect test is covered in the other test that does real deletion
@@ -242,7 +219,6 @@ test.describe("Delete User Functionality", () => {
     testContext,
     testPrisma,
   }) => {
-    
     await authenticatedPage.route("**/api/user", async (route) => {
       if (route.request().method() === "DELETE") {
         await route.fulfill({
@@ -257,12 +233,11 @@ test.describe("Delete User Functionality", () => {
 
     await authenticatedPage.goto("/settings");
 
-    
     const deleteButton = authenticatedPage.locator('button:has-text("Delete account")');
     await deleteButton.click();
 
     const confirmButton = authenticatedPage.locator('button:has-text("Yes, delete")');
-    
+
     const errorResponsePromise = authenticatedPage.waitForResponse(
       (resp) =>
         resp.url().includes("/api/user") &&
@@ -284,7 +259,7 @@ test.describe("Delete User Functionality", () => {
     expect(userAfterFailedDeletion).not.toBeNull();
 
     await expect(authenticatedPage.locator("text=Profile Settings")).toBeVisible();
-    
+
     await expect(authenticatedPage.locator('button:has-text("Delete account")')).toBeVisible();
   });
 
@@ -293,14 +268,12 @@ test.describe("Delete User Functionality", () => {
     testContext,
     testPrisma,
   }) => {
-    
     const response = await page.request.delete("/api/user");
     expect(response.status()).toBe(401);
-    
+
     const responseBody = await response.json();
     expect(responseBody.error).toBe("Unauthorized");
 
-    
     const user = await testPrisma.user.findUnique({
       where: { id: testContext.userId },
     });
@@ -312,20 +285,17 @@ test.describe("Delete User Functionality", () => {
     testContext,
     testPrisma,
   }) => {
-    
     await authenticatedPage.goto("/settings/organization");
 
-    
     await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
-    
-    
-    await expect(authenticatedPage.getByRole('heading', { name: 'Team Members', exact: true })).toBeVisible();
-    
-    
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Team Members", exact: true })
+    ).toBeVisible();
+
     const currentUserRow = authenticatedPage.locator(`text=${testContext.userEmail}`).locator("..");
     await expect(currentUserRow).toBeVisible();
-    
-    
+
     const deleteButtonInRow = currentUserRow.locator('button[title*="Remove"]');
     await expect(deleteButtonInRow).not.toBeVisible();
   });


### PR DESCRIPTION
Functionality for : #411 
<img width="798" height="288" alt="image" src="https://github.com/user-attachments/assets/40b38420-a551-40a0-9101-cb75d950787b" />
<img width="608" height="330" alt="image" src="https://github.com/user-attachments/assets/61bfc9ee-14eb-4eda-947d-993283063b27" />
<pre>
Implemented 8 end-to-end tests covering user account deletion flow including UI navigation, confirmation dialogs, and database cleanup verification
Fixed redirect behavior to send users to home page (/) instead of signin page after successful account deletion for better UX
Tests validate proper cascade deletion of user data (notes, sessions, invites) while preserving boards as per schema constraints

</pre>