### PR TITLE
fix: work flow when person who is not in organization is accessing a private board

### DIFF
--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -295,12 +295,12 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
   const fetchBoardData = async () => {
     try {
       const boardResponse = await fetch(`/api/boards/${boardId}`);
-      if (boardResponse.status === 404) {
+      if (boardResponse.status === 404 || boardResponse.status === 403) {
         setBoard(null);
         setLoading(false);
         return;
       }
-      if (boardResponse.status === 401 || boardResponse.status === 403) {
+      if (boardResponse.status === 401) {
         router.push("/auth/signin");
         return;
       }
@@ -351,14 +351,14 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
 
   if (!board) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen dark:bg-zinc-950 dark:text-zinc-100 flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-2">Board not found</h1>
           <p className="text-muted-foreground mb-4">
             This board doesn&apos;t exist or is not publicly accessible.
           </p>
 
-          <Button asChild>
+          <Button asChild variant="outline">
             <Link href="/">Go to Gumboard</Link>
           </Button>
         </div>


### PR DESCRIPTION
#411 
currently the flow is
1. you are login (but not in the organization of the board that is shared and now turn private) => you try to access it => it redirect you to  login page. 
> problem
 you are already login. it should only take us to auth/signup when the status return 401 (session not found)

https://github.com/user-attachments/assets/1f3a5e62-b98c-4323-af39-e5eac8c6d915


the expected flow:
1. you are login (but not in the organization of the board that is shared and now turn private) => you try to access it => it shows a appropriate message that the board is private

https://github.com/user-attachments/assets/8bbacd06-ef7f-463e-b532-9d9c26113b88

