### PR TITLE
fix: title and note cound card alignment

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -305,12 +305,14 @@ export default function Dashboard() {
                 <Link href={`/boards/${board.id}`} key={board.id}>
                   <Card
                     data-board-id={board.id}
-                    className="group h-full min-h-34 hover:shadow-lg transition-shadow cursor-pointer bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800"
+                    className="group h-full min-h-34 hover:shadow-lg transition-shadow cursor-pointer whitespace-nowrap bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800"
                   >
                     <CardHeader>
-                      <div className="flex items-center justify-between">
-                        <CardTitle className="text-lg dark:text-zinc-100">{board.name}</CardTitle>
-                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium text-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                      <div className="grid grid-cols-[1fr_auto] items-start justify-between gap-2">
+                        <CardTitle className="text-lg dark:text-zinc-100" title={board.name}>
+                          {board.name}
+                        </CardTitle>
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 mt-0.5">
                           {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
                         </span>
                       </div>


### PR DESCRIPTION
In relation, to #411 and fixes #426 by aligning the note counter badge to the top 

### Before

<img width="1470" height="818" alt="before_title_alignment" src="https://github.com/user-attachments/assets/e97f1171-4924-4554-bc11-bc3140a83675" />


### After

<img width="1459" height="491" alt="full_board_name" src="https://github.com/user-attachments/assets/1e0c65ac-6f40-4a8a-b77a-02678a61573c" />

### E2E

<img width="707" height="462" alt="e2e" src="https://github.com/user-attachments/assets/668f7cea-b403-4478-b4f3-80b1b483c087" />

