### PR TITLE
fix: flickering effect while checking items in a note

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -99,10 +99,7 @@ export function Note({
         item.id === itemId ? { ...item, checked: !item.checked } : item
       );
 
-      const sortedItems = [
-        ...updatedItems.filter((item) => !item.checked).sort((a, b) => a.order - b.order),
-        ...updatedItems.filter((item) => item.checked).sort((a, b) => a.order - b.order),
-      ];
+      const sortedItems = updatedItems.sort((a, b) => a.order - b.order);
 
       const optimisticNote = {
         ...note,


### PR DESCRIPTION
This PR fixes #429 and also addresses #411 by reducing UI jank when toggling checkboxes in mixed checked/unchecked lists.

When a note contains a mix of checked and unchecked items, toggling a checkbox causes a flickering effect. This happens because the optimistic update sorts checked and unchecked items separately, but when the server response arrives, the list reverts to its original order(irrespective of checked and unchecked), I think we should keep them consistent across both places how things are sorted , Fixed the sort (optimistic update) to just sort based on order

https://github.com/user-attachments/assets/985f9b86-edd7-449a-be6b-0db7ceb35b48