### PR TITLE
Fix note text on dark & light mode

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -119,7 +119,7 @@ export function ChecklistItem({
         value={editContent ?? item.content}
         onChange={(e) => onEditContentChange?.(e.target.value)}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 resize-none overflow-hidden outline-none",
+          "flex-1 border-none bg-transparent px-1 py-1 text-sm dark:text-zinc-300 text-zinc-700 resize-none overflow-hidden outline-none",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumboard/issues/411
There was very low contrast between note checklist item text and its background making it impossible to read.


### Before
<img width="1882" height="676" alt="image" src="https://github.com/user-attachments/assets/84475f90-66c5-4fdd-a365-04840aa2e880" />

----

### After
#### Light mode
<img width="1882" height="867" alt="image" src="https://github.com/user-attachments/assets/6f927e75-ca19-476a-8244-56ac696789dd" />

#### Dark mode
<img width="1882" height="867" alt="image" src="https://github.com/user-attachments/assets/2ac7e5ee-818f-428d-a059-adb85b5121d2" />
