### PR TITLE
fix calender picker icon in dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,3 +16,7 @@
 .dark .bg-dots {
   --dots-color: rgba(255, 255, 255, 0.08);
 }
+
+.dark input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}


### PR DESCRIPTION
**Issue**  
In dark mode, the `<Input type="date">` calendar picker indicator (calendar icon) was rendering in black, making it barely visible against the dark background. This resulted in a poor user experience and inconsistent UI design in dark mode.

**Fix**  
- Added a CSS rule targeting the WebKit-specific pseudo-element `::-webkit-calendar-picker-indicator` to ensure the icon is visible in dark mode.  
- Applied a dark-mode-specific selector to use `filter: invert(1)`, flipping the black icon to white while keeping light mode unchanged.

**Code changes**
```css
  .dark input[type="date"]::-webkit-calendar-picker-indicator {
    filter: invert(1);
  }
```
**Before**
<img width="632" height="114" alt="image" src="https://github.com/user-attachments/assets/edcfa3ea-842a-4137-9e21-addc57d5a9f1" />
**After**
<img width="309" height="111" alt="image" src="https://github.com/user-attachments/assets/e2eb0064-8c45-4955-b908-db2e5b08c358" />

