### PR TITLE
fix: dashboard card style

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -299,13 +299,15 @@ export default function Dashboard() {
                 <Link href={`/boards/${board.id}`} key={board.id}>
                   <Card
                     data-board-id={board.id}
-                    className="group hover:shadow-lg transition-shadow cursor-pointer bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800"
+                    className="group hover:shadow-lg transition-shadow cursor-pointer bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 h-full"
                   >
                     <CardHeader>
-                      <div className="flex items-center justify-between">
-                        <CardTitle className="text-lg dark:text-zinc-100">{board.name}</CardTitle>
+                      <div className="flex items-center justify-between gap-2">
+                        <CardTitle className="text-lg dark:text-zinc-100 line-clamp-1">
+                          {board.name}
+                        </CardTitle>
                         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium text-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                          {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
+                          {board._count.notes <= 99 ? board._count.notes : "99+"} {board._count.notes === 1 ? "note" : "notes"}
                         </span>
                       </div>
                     </CardHeader>


### PR DESCRIPTION
- added line clamp for title
- added 99+ text filter for notes count greater than 99
- fixed style for board with no description to match height with others