### PR TITLE
fix dark mode text contrast

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -119,7 +119,7 @@ export function ChecklistItem({
         value={editContent ?? item.content}
         onChange={(e) => onEditContentChange?.(e.target.value)}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 resize-none overflow-hidden outline-none",
+          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -357,7 +357,7 @@ export function Note({
             <AvatarImage src={note.user.image || ""} alt={note.user.name || ""} />
           </Avatar>
           <div className="flex flex-col">
-            <span className="text-sm font-bold text-gray-700 truncate max-w-20">
+            <span className="text-sm font-bold text-gray-700 dark:text-zinc-200 truncate max-w-20">
               {note.user.name ? note.user.name.split(" ")[0] : note.user.email.split("@")[0]}
             </span>
             <div className="flex flex-col">


### PR DESCRIPTION
ref #411 

Dark mode text contrast improvements.
Why: text in dark theme needed better legibility.

Before:
<img width="1582" height="980" alt="478409133-d1e33003-3c26-4ab4-8429-3fd5aa8a67db" src="https://github.com/user-attachments/assets/8a54004b-fe4c-488e-814c-7c37deffec18" />

After
<img width="1582" height="980" alt="478411261-47f366dc-0819-4651-9314-95d106e0afbb" src="https://github.com/user-attachments/assets/32823acd-51bc-4f17-bf3d-1645a53c3abc" />
