### PR TITLE
fix(ui): remove hover bg from note checklist

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -457,7 +457,7 @@ export function Note({
           >
             <DraggableContainer className="space-y-1">
               {note.checklistItems?.map((item) => (
-                <DraggableItem key={item.id} id={item.id}>
+                <DraggableItem key={item.id} id={item.id} className="hover:bg-transparent">
                   <ChecklistItemComponent
                     item={item}
                     onToggle={handleToggleChecklistItem}

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -680,7 +680,7 @@ test.describe("Note Management", () => {
     }) => {
       // Create a board for testing all notes view
       const boardName = testContext.getBoardName("All Notes Test Board");
-      const board = await testPrisma.board.create({
+      await testPrisma.board.create({
         data: {
           name: boardName,
           description: testContext.prefix("All notes test board"),


### PR DESCRIPTION
# Description
Removed hover background from note checklist items for a cleaner ui

## Before
https://github.com/user-attachments/assets/150db4e5-a8ce-4119-861b-88086ded6cb0

## After
https://github.com/user-attachments/assets/b0363950-6e45-49de-87af-9e6e2cb19aa8

