### PR TITLE
fix long board name issue

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -937,7 +937,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
               {showBoardDropdown && (
                 <div className="fixed sm:absolute left-0 mt-1 w-full sm:w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 z-50 max-h-80 overflow-y-auto">
-                  <div className="p-2 flex flex-col gap-1">
+                  <div className="p-2 flex flex-col gap-1 break-all line-clamp-1">
                     {/* Boards */}
                     {allBoards.map((b) => (
                       <Link
@@ -950,7 +950,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                         }`}
                         onClick={() => setShowBoardDropdown(false)}
                       >
-                        <div>{b.name}</div>
+                        <div className="line-clamp-2 break-all">{b.name}</div>
                       </Link>
                     ))}
 


### PR DESCRIPTION
- added 2 lines limit for displaying board name

Before
<img width="1919" height="860" alt="Screenshot 2025-08-16 004044" src="https://github.com/user-attachments/assets/ca4209bb-5562-49f1-9d17-6808b9b7317a" />
After
<img width="1919" height="973" alt="Screenshot 2025-08-16 004213" src="https://github.com/user-attachments/assets/0503328c-31ba-47b1-b512-385daa36fede" />
