### PR TITLE
feat: add color picker to board with e2e tests

### DIFF
--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -72,7 +72,8 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const boardId = (await params).id;
-    const { name, description, isPublic, sendSlackUpdates } = await request.json();
+    const { name, description, isPublic, sendSlackUpdates, color, coverImage } =
+      await request.json();
 
     // Check if board exists and user has access
     const board = await db.board.findUnique({
@@ -100,9 +101,13 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // For name/description/isPublic updates, check if user can edit this board (board creator or admin)
+    // For name/description/isPublic/color/coverImage updates, check if user can edit this board (board creator or admin)
     if (
-      (name !== undefined || description !== undefined || isPublic !== undefined) &&
+      (name !== undefined ||
+        description !== undefined ||
+        isPublic !== undefined ||
+        color !== undefined ||
+        coverImage !== undefined) &&
       board.createdBy !== session.user.id &&
       !currentUser.isAdmin
     ) {
@@ -117,12 +122,16 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       description?: string;
       isPublic?: boolean;
       sendSlackUpdates?: boolean;
+      color?: string;
+      coverImage?: string;
     } = {};
     if (name !== undefined) updateData.name = name?.trim() || board.name;
     if (description !== undefined)
       updateData.description = description?.trim() || board.description;
     if (isPublic !== undefined) updateData.isPublic = isPublic;
     if (sendSlackUpdates !== undefined) updateData.sendSlackUpdates = sendSlackUpdates;
+    if (color !== undefined) updateData.color = color;
+    if (coverImage !== undefined) updateData.coverImage = coverImage;
 
     const updatedBoard = await db.board.update({
       where: { id: boardId },

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -29,6 +29,8 @@ export async function GET() {
         name: true,
         description: true,
         isPublic: true,
+        color: true,
+        coverImage: true,
         createdBy: true,
         createdAt: true,
         updatedAt: true,
@@ -60,7 +62,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { name, description, isPublic } = await request.json();
+    const { name, description, isPublic, color, coverImage } = await request.json();
 
     if (!name) {
       return NextResponse.json({ error: "Board name is required" }, { status: 400 });
@@ -83,6 +85,8 @@ export async function POST(request: NextRequest) {
         name,
         description,
         isPublic: Boolean(isPublic || false),
+        color,
+        coverImage,
         organizationId: user.organizationId,
         createdBy: session.user.id,
       },
@@ -91,6 +95,8 @@ export async function POST(request: NextRequest) {
         name: true,
         description: true,
         isPublic: true,
+        color: true,
+        coverImage: true,
         createdBy: true,
         createdAt: true,
         updatedAt: true,

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { FullPageLoader } from "@/components/ui/loader";
 import { FilterPopover } from "@/components/ui/filter-popover";
+import { ColorPicker } from "@/components/ui/color-picker";
 import { Note as NoteCard } from "@/components/note";
 
 import {
@@ -42,6 +43,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   const [showAddBoard, setShowAddBoard] = useState(false);
   const [newBoardName, setNewBoardName] = useState("");
   const [newBoardDescription, setNewBoardDescription] = useState("");
+  const [newBoardColor, setNewBoardColor] = useState("");
   const [boardId, setBoardId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
@@ -68,6 +70,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     description: "",
     isPublic: false,
     sendSlackUpdates: true,
+    color: "",
+    coverImage: "",
   });
   const [copiedPublicUrl, setCopiedPublicUrl] = useState(false);
   const [deleteConfirmDialog, setDeleteConfirmDialog] = useState(false);
@@ -383,6 +387,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           setShowAddBoard(false);
           setNewBoardName("");
           setNewBoardDescription("");
+          setNewBoardColor("");
         }
       }
     };
@@ -600,6 +605,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           description: board.description || "",
           isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
           sendSlackUpdates: (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+          color: (board as { color?: string })?.color ?? "",
+          coverImage: (board as { coverImage?: string })?.coverImage ?? "",
         });
       }
 
@@ -793,6 +800,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         body: JSON.stringify({
           name: newBoardName,
           description: newBoardDescription,
+          color: newBoardColor,
         }),
       });
 
@@ -801,6 +809,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         setAllBoards([board, ...allBoards]);
         setNewBoardName("");
         setNewBoardDescription("");
+        setNewBoardColor("");
         setShowAddBoard(false);
         setShowBoardDropdown(false);
         router.push(`/boards/${board.id}`);
@@ -827,6 +836,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     description?: string;
     isPublic?: boolean;
     sendSlackUpdates: boolean;
+    color?: string;
+    coverImage?: string;
   }) => {
     try {
       const response = await fetch(`/api/boards/${boardId}`, {
@@ -843,6 +854,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           description: board.description || "",
           isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
           sendSlackUpdates: (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+          color: (board as { color?: string })?.color ?? "",
+          coverImage: (board as { coverImage?: string })?.coverImage ?? "",
         });
         setBoardSettingsDialog(false);
       }
@@ -1010,6 +1023,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                             isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
                             sendSlackUpdates:
                               (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+                            color: (board as { color?: string })?.color ?? "",
+                            coverImage: (board as { coverImage?: string })?.coverImage ?? "",
                           });
                           setBoardSettingsDialog(true);
                           setShowBoardDropdown(false);
@@ -1179,6 +1194,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             setShowAddBoard(false);
             setNewBoardName("");
             setNewBoardDescription("");
+            setNewBoardColor("");
           }}
         >
           <div
@@ -1215,6 +1231,16 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700"
                   />
                 </div>
+                <div>
+                  <label className="block text-sm font-medium text-foreground dark:text-zinc-200 mb-1">
+                    Board Color (optional)
+                  </label>
+                  <ColorPicker
+                    value={newBoardColor}
+                    onChange={setNewBoardColor}
+                    className="w-full"
+                  />
+                </div>
               </div>
               <div className="flex justify-end space-x-3 mt-6">
                 <Button
@@ -1224,6 +1250,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     setShowAddBoard(false);
                     setNewBoardName("");
                     setNewBoardDescription("");
+                    setNewBoardColor("");
                   }}
                   className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-300 dark:border-zinc-700 hover:bg-zinc-100 hover:text-foreground hover:border-gray-300 dark:hover:bg-zinc-800"
                 >
@@ -1302,6 +1329,19 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 placeholder="Enter board description"
                 className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700"
               />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-foreground dark:text-zinc-200 mb-1">
+                Board Color (optional)
+              </label>
+              <ColorPicker
+                value={boardSettings.color}
+                onChange={(color) => setBoardSettings((prev) => ({ ...prev, color }))}
+                className="w-full"
+              />
+              <p className="text-xs text-muted-foreground dark:text-zinc-400 mt-1">
+                Choose a color to help distinguish this board
+              </p>
             </div>
             <div className="space-y-4">
               <div className="flex items-center space-x-2">

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -29,6 +29,8 @@ export interface Board {
   id: string;
   name: string;
   description: string | null;
+  color?: string | null;
+  coverImage?: string | null;
 }
 
 export interface Note {

--- a/components/ui/color-picker.tsx
+++ b/components/ui/color-picker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ColorPickerProps {
+  value?: string;
+  onChange: (color: string) => void;
+  className?: string;
+}
+
+const predefinedColors = [
+  "#3b82f6", // Blue
+  "#8b5cf6", // Violet
+  "#06b6d4", // Cyan
+  "#10b981", // Emerald
+  "#f59e0b", // Amber
+  "#ef4444", // Red
+  "#ec4899", // Pink
+  "#84cc16", // Lime
+  "#6366f1", // Indigo
+  "#f97316", // Orange
+  "#14b8a6", // Teal
+  "#a855f7", // Purple
+  "#64748b", // Slate
+  "#374151", // Gray
+  "#1f2937", // Dark Gray
+  "#000000", // Black
+];
+
+export function ColorPicker({ value, onChange, className }: ColorPickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          data-testid="color-picker-trigger"
+          className={cn(
+            "w-[200px] justify-start gap-2 border-gray-200 dark:border-zinc-800",
+            className
+          )}
+        >
+          <div
+            className="w-4 h-4 rounded border border-gray-300 dark:border-zinc-600 flex-shrink-0"
+            style={{ backgroundColor: value || "#e5e7eb" }}
+          />
+          {value ? (
+            <span className="text-sm">{value.toUpperCase()}</span>
+          ) : (
+            <span className="text-sm text-muted-foreground">Select color...</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-4 bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800">
+        <div className="grid grid-cols-4 gap-2">
+          {predefinedColors.map((color, index) => (
+            <Button
+              key={color}
+              variant="outline"
+              size="sm"
+              data-testid={`color-option-${index}`}
+              className={cn(
+                "w-12 h-12 p-0 border-gray-200 dark:border-zinc-700 hover:border-gray-400 dark:hover:border-zinc-500",
+                value === color && "ring-2 ring-blue-500 ring-offset-2"
+              )}
+              style={{ backgroundColor: color }}
+              onClick={() => {
+                onChange(color);
+                setOpen(false);
+              }}
+            >
+              {value === color && <Check className="w-4 h-4 text-white drop-shadow-lg" />}
+            </Button>
+          ))}
+        </div>
+        <div className="mt-4 pt-4 border-t border-gray-200 dark:border-zinc-800">
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="color-clear"
+            className="w-full text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              onChange("");
+              setOpen(false);
+            }}
+          >
+            Clear Color
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/prisma/migrations/20250815194519_add_board_color_and_cover/migration.sql
+++ b/prisma/migrations/20250815194519_add_board_color_and_cover/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "boards" ADD COLUMN     "color" TEXT,
+ADD COLUMN     "coverImage" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,8 @@ model Board {
   description    String?
   isPublic       Boolean      @default(false)
   sendSlackUpdates Boolean    @default(true)
+  color          String?
+  coverImage     String?
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   createdBy      String

--- a/tests/e2e/board-colors.spec.ts
+++ b/tests/e2e/board-colors.spec.ts
@@ -1,0 +1,244 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Board Colors", () => {
+  test("should create a board with a color from dashboard", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    await authenticatedPage.goto("/dashboard");
+    const boardName = testContext.getBoardName("Colored Test Board");
+    const boardDescription = "Test board with color";
+
+    await authenticatedPage.click('button:has-text("Add Board")');
+
+    await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
+    await authenticatedPage.fill('input[placeholder*="board description"]', boardDescription);
+
+    await authenticatedPage.click('[data-testid="color-picker-trigger"]');
+    await authenticatedPage.click('[data-testid="color-option-0"]');
+
+    const responsePromise = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes("/api/boards") && resp.status() === 201
+    );
+
+    await authenticatedPage.click('button:has-text("Create Board")');
+    await responsePromise;
+
+    await expect(
+      authenticatedPage.locator(`[data-slot="card-title"]:has-text("${boardName}")`)
+    ).toBeVisible();
+
+    const board = await testPrisma.board.findFirst({
+      where: {
+        name: boardName,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    expect(board).toBeTruthy();
+    expect(board?.name).toBe(boardName);
+    expect(board?.description).toBe(boardDescription);
+    expect(board?.color).toBeTruthy(); // Should have a color value
+    expect(board?.createdBy).toBe(testContext.userId);
+  });
+
+  test("should edit board color through board settings", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create a board with initial color
+    const initialColor = "#ef4444"; // red
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Color Edit Test"),
+        description: testContext.prefix("Board for color editing"),
+        color: initialColor,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Open board settings
+    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
+    await authenticatedPage.click('button:has-text("Board settings")');
+
+    // Verify current color is displayed
+    await expect(authenticatedPage.locator("text=Board settings")).toBeVisible();
+
+    // Change the color (select a different color)
+    await authenticatedPage.click('[data-testid="color-picker-trigger"]');
+    await authenticatedPage.click('[data-testid="color-option-2"]'); // Different color
+
+    // Save settings
+    const saveResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
+    await authenticatedPage.click('button:has-text("Save settings")');
+    await saveResponse;
+
+    // Verify in database that color changed
+    const updatedBoard = await testPrisma.board.findUnique({
+      where: { id: board.id },
+    });
+    expect(updatedBoard?.color).not.toBe(initialColor);
+    expect(updatedBoard?.color).toBeTruthy();
+
+    // Verify settings dialog closed
+    await expect(authenticatedPage.locator("text=Board settings")).not.toBeVisible();
+  });
+
+  test("should clear board color", async ({ authenticatedPage, testContext, testPrisma }) => {
+    // Create a board with a color
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Color Clear Test"),
+        description: testContext.prefix("Board for color clearing"),
+        color: "#10b981", // green
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Open board settings
+    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
+    await authenticatedPage.click('button:has-text("Board settings")');
+
+    // Clear the color
+    await authenticatedPage.click('[data-testid="color-picker-trigger"]');
+    await authenticatedPage.click('[data-testid="color-clear"]');
+
+    // Save settings
+    const saveResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
+    await authenticatedPage.click('button:has-text("Save settings")');
+    await saveResponse;
+
+    // Verify in database that color is cleared
+    const updatedBoard = await testPrisma.board.findUnique({
+      where: { id: board.id },
+    });
+    expect(updatedBoard?.color).toBe("");
+
+    // Verify settings dialog closed
+    await expect(authenticatedPage.locator("text=Board settings")).not.toBeVisible();
+  });
+
+  test("should display board color on dashboard", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create boards with different colors
+    const redBoard = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Red Board"),
+        description: testContext.prefix("Red colored board"),
+        color: "#ef4444",
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    const blueBoard = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Blue Board"),
+        description: testContext.prefix("Blue colored board"),
+        color: "#3b82f6",
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    const noColorBoard = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("No Color Board"),
+        description: testContext.prefix("Board without color"),
+        color: "",
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto("/dashboard");
+
+    await expect(
+      authenticatedPage.locator(`[data-slot="card-title"]:has-text("${redBoard.name}")`)
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.locator(`[data-slot="card-title"]:has-text("${blueBoard.name}")`)
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.locator(`[data-slot="card-title"]:has-text("${noColorBoard.name}")`)
+    ).toBeVisible();
+  });
+
+  test("should preserve board color during other board updates", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create a board with color
+    const originalColor = "#8b5cf6"; // purple
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Color Preserve Test"),
+        description: testContext.prefix("Board for color preservation"),
+        color: originalColor,
+        sendSlackUpdates: true,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Open board settings
+    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
+    await authenticatedPage.click('button:has-text("Board settings")');
+
+    // Update other settings but leave color unchanged
+    await authenticatedPage.fill(
+      'input[value*="Color Preserve Test"]',
+      testContext.getBoardName("Updated Name")
+    );
+
+    // Toggle Slack updates
+    const slackCheckbox = authenticatedPage.locator("#sendSlackUpdates");
+    await slackCheckbox.uncheck();
+
+    // Save settings
+    const saveResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
+    await authenticatedPage.click('button:has-text("Save settings")');
+    await saveResponse;
+
+    // Verify in database that color is preserved
+    const updatedBoard = await testPrisma.board.findUnique({
+      where: { id: board.id },
+    });
+    expect(updatedBoard?.color).toBe(originalColor); // Color should be unchanged
+    expect(updatedBoard?.name).toContain("Updated Name");
+    expect(updatedBoard?.sendSlackUpdates).toBe(false);
+  });
+});


### PR DESCRIPTION
Could be considered as an enhancement https://github.com/antiwork/gumboard/issues/411

Adding different colors (color picker), or background images to boards would be nice and help users to visually distinguish boards faster

https://github.com/user-attachments/assets/b2b1201c-4067-46f1-ab46-c0beed9871f9

All and newly added tests pass