### PR TITLE
test: verify board query omits archived notes

### DIFF
--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -129,7 +129,14 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       data: updateData,
       include: {
         _count: {
-          select: { notes: true },
+          select: {
+            notes: {
+              where: {
+                deletedAt: null,
+                archivedAt: null,
+              },
+            },
+          },
         },
         organization: {
           select: {

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -37,6 +37,7 @@ export async function GET() {
             notes: {
               where: {
                 deletedAt: null,
+                archivedAt: null,
               },
             },
           },
@@ -96,7 +97,14 @@ export async function POST(request: NextRequest) {
         updatedAt: true,
         organizationId: true,
         _count: {
-          select: { notes: true },
+          select: {
+            notes: {
+              where: {
+                deletedAt: null,
+                archivedAt: null,
+              },
+            },
+          },
         },
       },
     });

--- a/tests/e2e/boards-query.spec.ts
+++ b/tests/e2e/boards-query.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test("should exclude archived notes from boards query", async ({
+  authenticatedPage,
+  testPrisma,
+  testContext,
+}) => {
+  const board = await testPrisma.board.create({
+    data: {
+      name: testContext.getBoardName("Test Board"),
+      description: testContext.prefix("Board description"),
+      createdBy: testContext.userId,
+      organizationId: testContext.organizationId,
+    },
+  });
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      archivedAt: null,
+      createdBy: testContext.userId,
+      boardId: board.id,
+    },
+  });
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      archivedAt: new Date(),
+      createdBy: testContext.userId,
+      boardId: board.id,
+    },
+  });
+
+  const boardsResponse = authenticatedPage.waitForResponse(
+    (resp) => resp.url().includes("/api/boards") && resp.ok()
+  );
+  await authenticatedPage.goto("/dashboard");
+  await boardsResponse;
+
+  const boardCard = authenticatedPage.locator(`[data-board-id="${board.id}"]`);
+  await expect(boardCard).toContainText("1 note");
+});


### PR DESCRIPTION
Ref #411 

Summary

- Excluded archived notes when counting notes for each board by filtering both deleted and archived notes in board queries, ensuring counts reflect only active notes
- Applied the same archived-note filter to board update responses so that note counts remain consistent after board modifications
- Added an end-to-end test that creates both active and archived notes and verifies the dashboard displays a count of only active notes

E2e
<img width="649" height="255" alt="Screenshot From 2025-08-16 08-23-05" src="https://github.com/user-attachments/assets/77133541-8697-495f-9740-584bc4b13db4" />
