### PR TITLE
fix: prevent board creation with whitespace-only names (with e2e testing)

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -63,9 +63,11 @@ export async function POST(request: NextRequest) {
 
     const { name, description, isPublic } = await request.json();
 
-    if (!name) {
-      return NextResponse.json({ error: "Board name is required" }, { status: 400 });
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json({ error: "Board name is required and cannot be empty or only whitespace" }, { status: 400 });
     }
+
+    const trimmedName = name.trim();
 
     const user = await db.user.findUnique({
       where: { id: session.user.id },
@@ -81,7 +83,7 @@ export async function POST(request: NextRequest) {
     // Create new board
     const board = await db.board.create({
       data: {
-        name,
+        name: trimmedName,
         description,
         isPublic: Boolean(isPublic || false),
         organizationId: user.organizationId,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -52,7 +52,10 @@ export type DashboardBoard = Board & {
 };
 
 const formSchema = z.object({
-  name: z.string().min(1, "Board name is required"),
+  name: z.string().min(1, "Board name is required").refine(
+    (value) => value.trim().length > 0,
+    "Board name cannot be empty"
+  ),
   description: z.string().optional(),
 });
 
@@ -123,6 +126,7 @@ export default function Dashboard() {
 
   const handleAddBoard = async (values: z.infer<typeof formSchema>) => {
     const { name, description } = values;
+    const trimmedName = name.trim();
     try {
       const response = await fetch("/api/boards", {
         method: "POST",
@@ -130,7 +134,7 @@ export default function Dashboard() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          name,
+          name: trimmedName,
           description,
         }),
       });

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -72,6 +72,70 @@ test.describe("Board Management", () => {
     await expect(createButton).toBeEnabled();
   });
 
+  test("should prevent creating boards with whitespace-only names", async ({ 
+    authenticatedPage, 
+    testContext 
+  }) => {
+    await authenticatedPage.goto("/dashboard");
+
+    await authenticatedPage.getByRole("button", { name: "Add Board" }).click();
+
+    const nameInput = authenticatedPage.locator('input[placeholder*="board name"]');
+    const createButton = authenticatedPage.getByRole("button", { name: "Create board" });
+
+
+    await nameInput.fill("   ");
+    await createButton.click();
+    
+
+    await expect(authenticatedPage.locator("text=Board name cannot be empty")).toBeVisible();
+    
+   
+    await nameInput.fill("\t  \t ");
+    await createButton.click();
+    
+
+    await expect(authenticatedPage.locator("text=Board name cannot be empty")).toBeVisible();
+
+  
+    await expect(authenticatedPage.locator('text="Create New Board"')).toBeVisible();
+  });
+
+  test("should trim whitespace from board names", async ({ 
+    authenticatedPage, 
+    testContext,
+    testPrisma 
+  }) => {
+    await authenticatedPage.goto("/dashboard");
+
+    const boardName = testContext.getBoardName("Test Board");
+    const nameWithWhitespace = `  ${boardName}  `;
+
+    await authenticatedPage.getByRole("button", { name: "Add Board" }).click();
+    
+    const nameInput = authenticatedPage.locator('input[placeholder*="board name"]');
+    await nameInput.fill(nameWithWhitespace);
+    
+    const responsePromise = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes("/api/boards") && resp.status() === 201
+    );
+
+    await authenticatedPage.getByRole("button", { name: "Create board" }).click();
+    await responsePromise;
+
+    const board = await testPrisma.board.findFirst({
+      where: {
+        name: boardName, 
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    expect(board).toBeTruthy();
+    expect(board?.name).toBe(boardName); 
+    expect(board?.name).not.toBe(nameWithWhitespace); 
+  });
+
   test.describe("Board Not Found", () => {
     test("should display not found page for invalid board ID", async ({ authenticatedPage }) => {
       const invalidBoardId = "invalid-board-id";


### PR DESCRIPTION
Enhancement: #411 
Users could create boards with whitespace-only names (spaces, tabs) which resulted in boards with meaningless names and poor UX.
Before:
<img width="376" height="212" alt="image" src="https://github.com/user-attachments/assets/30c80dde-eaa1-465a-99f1-a574908640ae" />

After:
<img width="538" height="282" alt="image" src="https://github.com/user-attachments/assets/80a1b5f4-9430-4b7d-8fb2-9fba8c2320b7" />

