### PR TITLE
fix: date picker month navigation and future date restrictions

### DIFF
--- a/components/ui/date-range-picker.tsx
+++ b/components/ui/date-range-picker.tsx
@@ -129,8 +129,8 @@ function DateRangePicker({
                   <Calendar
                     mode="single"
                     selected={internalStartDate || undefined}
-                    month={internalStartDate || undefined}
                     onSelect={handleStartCalendarSelect}
+                    disabled={(date) => date > new Date()}
                     modifiersClassNames={{
                       outside: "text-gray-400 opacity-50 pointer-events-none",
                     }}
@@ -166,10 +166,9 @@ function DateRangePicker({
                   <Calendar
                     mode="single"
                     selected={internalEndDate || undefined}
-                    month={internalEndDate || internalStartDate || undefined}
                     onSelect={handleEndCalendarSelect}
-                    disabled={(date) =>
-                      internalStartDate ? isAfter(internalStartDate, date) : false
+                    disabled={(date) => 
+                      date > new Date() || (internalStartDate ? date < internalStartDate : false)
                     }
                     modifiersClassNames={{
                       outside: "text-gray-400 opacity-50 pointer-events-none",


### PR DESCRIPTION
Fixed month navigation and future date selection issues by removing month conflicting props and adding proper disabled functions, addressing #411.

Before

https://github.com/user-attachments/assets/96650fb9-3297-4d4e-8e15-1c2b4cb8593c

After

https://github.com/user-attachments/assets/d77c818d-af51-487d-9698-9230ff0311fa

