### PR TITLE
refactor: move board settings to the navbar for quick access

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -728,27 +728,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     >
                       <span className="font-medium">Create new board</span>
                     </Button>
-                    {boardId !== "all-notes" && boardId !== "archive" && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setBoardSettings({
-                            name: board?.name || "",
-                            description: board?.description || "",
-                            isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
-                            sendSlackUpdates:
-                              (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
-                          });
-                          setBoardSettingsDialog(true);
-                          setShowBoardDropdown(false);
-                        }}
-                        className="flex items-center w-full px-4 py-2"
-                      >
-                        <Settings className="w-4 h-4 mr-2" />
-                        <span className="font-medium">Board settings</span>
-                      </Button>
-                    )}
                   </div>
                 </div>
               )}
@@ -756,7 +735,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700" />
 
             {/* Filter Popover */}
-            <div className="relative board-dropdown mr-0" data-slot="filter-popover">
+            <div className="relative board-dropdown mr-1" data-slot="filter-popover">
               <FilterPopover
                 startDate={dateRange.startDate}
                 endDate={dateRange.endDate}
@@ -771,9 +750,30 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   setSelectedAuthor(authorId);
                   updateURL(undefined, undefined, authorId);
                 }}
-                className="w-fit"
+                className="w-fit size-9"
               />
             </div>
+            {boardId !== "all-notes" && boardId !== "archive" && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setBoardSettings({
+                    name: board?.name || "",
+                    description: board?.description || "",
+                    isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
+                    sendSlackUpdates:
+                      (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+                  });
+                  setBoardSettingsDialog(true);
+                }}
+                aria-label="Board settings"
+                title="Board settings"
+                className="flex items-center size-9"
+              >
+                <Settings className="size-4" />
+              </Button>
+            )}
           </div>
 
           {/* Right side - Search, Add Note and User dropdown */}

--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -52,14 +52,14 @@ function FilterPopover({
             variant="outline"
             disabled={disabled}
             className={cn(
-              "flex items-center text-sm gap-0 rounded-md py-2 cursor-pointer w-full sm:w-auto",
+              "flex items-center text-sm gap-0 rounded-md py-2 cursor-pointer w-full",
               disabled && "opacity-50 cursor-not-allowed"
             )}
           >
-            <ListFilter className="w-4 h-4 mr-1 text-muted-foreground" />
+            <ListFilter className="w-4 h-4 text-muted-foreground" />
             <span className="text-foreground">
               {filterCount > 0 && (
-                <span className="px-1.5 py-0.5 text-xs bg-primary/10 text-primary rounded-md">
+                <span className="px-0.5 py-0.5 text-xs bg-primary/10 text-primary rounded-md">
                   {filterCount}
                 </span>
               )}

--- a/tests/e2e/board-settings.spec.ts
+++ b/tests/e2e/board-settings.spec.ts
@@ -19,8 +19,7 @@ test.describe("Board Settings", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
-    await authenticatedPage.click('button:has-text("Board settings")');
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
 
     await expect(authenticatedPage.locator("text=Board settings")).toBeVisible();
     await expect(
@@ -53,8 +52,7 @@ test.describe("Board Settings", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
-    await authenticatedPage.click('button:has-text("Board settings")');
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
 
     const checkbox = authenticatedPage.locator("#sendSlackUpdates");
     await expect(checkbox).toBeChecked();
@@ -147,8 +145,7 @@ test.describe("Board Settings", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
-    await authenticatedPage.click('button:has-text("Board settings")');
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
 
     await expect(authenticatedPage.locator("text=Board settings")).toBeVisible();
     await expect(
@@ -178,8 +175,7 @@ test.describe("Board Settings", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
-    await authenticatedPage.click('button:has-text("Board settings")');
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
 
     const checkbox = authenticatedPage.locator("#sendSlackUpdates");
     await expect(checkbox).toBeChecked();
@@ -198,8 +194,7 @@ test.describe("Board Settings", () => {
     expect(unchangedBoard?.sendSlackUpdates).toBe(true);
 
     // Reopen settings to verify UI reflects unchanged state
-    await authenticatedPage.click(`button:has(div:has-text("${board.name}"))`);
-    await authenticatedPage.click('button:has-text("Board settings")');
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
 
     await expect(checkbox).toBeChecked();
   });


### PR DESCRIPTION
In relation to #411 

1. Moves board settings to the navbar for quick access
2. Fixes center alignment of filter button icon

Before:

https://github.com/user-attachments/assets/0e119c4c-0833-47d6-ac5c-96f3209162b4


After:

https://github.com/user-attachments/assets/aa524966-ff24-4aa9-bb56-8a499ffb96a8


Tests Passing:

<img width="1404" height="722" alt="board-settings-spec-passing" src="https://github.com/user-attachments/assets/6d0d8a82-9887-4e90-8eaa-6c6221bca1aa" />


 