### PR TITLE
chore: add a basic pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+<!-- This is a template, add and remove sections as you see fit for the PR -->
+
+### Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+**Related Issue:** <!-- Optional link to related issue (e.g., Fixes #411, Closes #123, Related to #456) -->
+
+### What's Changed
+
+<!-- Describe what changes were made and why -->
+
+<!-- ### UI Changes (if applicable)
+
+#### Before
+
+Add screenshots or video showing the UI before your changes
+
+#### After
+
+Add screenshots or GIFs showing the UI after your changes -->
+
+### Tests
+
+#### Tests Passing
+
+<!-- Add screenshots of test results passing locally,  -->
+
+- [ ] All tests pass locally
+- [ ] Screenshots of test suite passing included
+
+### Checklist
+
+- [ ] Self-reviewed PR
+<!-- - [ ] Added explanatory comments for complex changes
+- [ ] Documentation updated if behavior changes -->
+
+<!-- ### Frontend (if applicable)
+- [ ] Designed for both light and dark mode
+- [ ] Responsive design considered 
+-->
+
+<!-- ### Backend (if applicable)  
+- [ ] Database schema changes reflected in frontend types -->
+
+<!--
+## Additional Notes
+Any additional context for reviewers
+
+## Database Changes
+- [ ] Migration scripts included
+- [ ] Schema changes documented
+-->


### PR DESCRIPTION
### Description

Incorporates some of the practices from the contributing guidelines into a PR template so people don't forget to add relevant information  