### PR TITLE
feat: Add Skeleton loaders

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -676,10 +676,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                       <Link
                         key={b.id}
                         href={`/boards/${b.id}`}
-                        className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600  dark:hover:text-white ${b.id === boardId
-                          ? "bg-zinc-100 dark:bg-zinc-800 text-foreground dark:text-zinc-100 font-semibold"
-                          : "text-foreground dark:text-zinc-100"
-                          }`}
+                        className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600  dark:hover:text-white ${
+                          b.id === boardId
+                            ? "bg-zinc-100 dark:bg-zinc-800 text-foreground dark:text-zinc-100 font-semibold"
+                            : "text-foreground dark:text-zinc-100"
+                        }`}
                         onClick={() => setShowBoardDropdown(false)}
                       >
                         <div>{b.name}</div>
@@ -693,10 +694,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     {/* All Notes Option */}
                     <Link
                       href="/boards/all-notes"
-                      className={`rounded-lg font-medium block px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600 ${boardId === "all-notes"
-                        ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
-                        : "text-foreground dark:text-white"
-                        }`}
+                      className={`rounded-lg font-medium block px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600 ${
+                        boardId === "all-notes"
+                          ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
+                          : "text-foreground dark:text-white"
+                      }`}
                       onClick={() => setShowBoardDropdown(false)}
                     >
                       <div>All notes</div>
@@ -705,10 +707,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     {/* Archive Option */}
                     <Link
                       href="/boards/archive"
-                      className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600 ${boardId === "archive"
-                        ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
-                        : "text-foreground dark:text-white"
-                        }`}
+                      className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:text-white hover:bg-sky-600 dark:hover:bg-sky-600 ${
+                        boardId === "archive"
+                          ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
+                          : "text-foreground dark:text-white"
+                      }`}
                       onClick={() => setShowBoardDropdown(false)}
                     >
                       <div>All archived</div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -419,4 +419,4 @@ const DashboardSkeleton = () => {
       </div>
     </div>
   );
-}
+};

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -53,20 +53,22 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
             <nav className="flex flex-row lg:flex-col space-x-2 lg:space-x-0 lg:space-y-2 overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0">
               <Link
                 href="/settings"
-                className={`flex-shrink-0 lg:w-full flex items-center px-3 sm:px-4 py-2 sm:py-3 text-left rounded-lg transition-colors ${isProfileActive
-                  ? "bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-900"
-                  : "text-foreground dark:text-zinc-100 hover:bg-accent dark:hover:bg-zinc-800"
-                  }`}
+                className={`flex-shrink-0 lg:w-full flex items-center px-3 sm:px-4 py-2 sm:py-3 text-left rounded-lg transition-colors ${
+                  isProfileActive
+                    ? "bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-900"
+                    : "text-foreground dark:text-zinc-100 hover:bg-accent dark:hover:bg-zinc-800"
+                }`}
               >
                 <UserIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-2 sm:mr-3" />
                 <span className="text-sm sm:text-base whitespace-nowrap">Profile</span>
               </Link>
               <Link
                 href="/settings/organization"
-                className={`flex-shrink-0 lg:w-full flex items-center px-3 sm:px-4 py-2 sm:py-3 text-left rounded-lg transition-colors ${isOrganizationActive
-                  ? "bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-900"
-                  : "text-foreground dark:text-zinc-100 hover:bg-accent dark:hover:bg-zinc-800"
-                  }`}
+                className={`flex-shrink-0 lg:w-full flex items-center px-3 sm:px-4 py-2 sm:py-3 text-left rounded-lg transition-colors ${
+                  isOrganizationActive
+                    ? "bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-900"
+                    : "text-foreground dark:text-zinc-100 hover:bg-accent dark:hover:bg-zinc-800"
+                }`}
               >
                 <Building2 className="w-4 h-4 sm:w-5 sm:h-5 mr-2 sm:mr-3" />
                 <span className="text-sm sm:text-base whitespace-nowrap">Organization</span>
@@ -131,4 +133,4 @@ const SettingsSkeleton = () => {
       </div>
     </div>
   );
-}
+};

--- a/components/board-skeleton.tsx
+++ b/components/board-skeleton.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from "./ui/skeleton";
 
-export 
-const BoardPageSkeleton = () => {
+export const BoardPageSkeleton = () => {
   const skeletonNoteCount = 5;
   return (
     <div className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots">
@@ -48,5 +47,5 @@ const BoardPageSkeleton = () => {
         ))}
       </div>
     </div>
-  )
-}
+  );
+};

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -7,7 +7,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("bg-neutral-200 dark:bg-neutral-800 animate-pulse rounded-md", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };


### PR DESCRIPTION
Comes under #411
Fixes #488 

This PR introduces skeleton loaders to improve the user experience during data fetching.
Affected Pages:
- `/dashboard`
- `/boards/[id]`
-  `/settings`
- `/settings/organization`

## Demo
### Dashboard Page
#### Before

https://github.com/user-attachments/assets/b3db2e9c-9b1c-4210-8b1c-0ae3ca08ff4d

#### After
https://github.com/user-attachments/assets/cce28d41-1693-4882-b340-29ce9bbc1c6d

### Boards Page
#### Before


https://github.com/user-attachments/assets/11f9287a-9db0-4a72-90c6-550c9723b5cc

#### After

https://github.com/user-attachments/assets/5c77fa7b-3ae4-46ab-9597-aa68d5191e01

## Settings Page (Demo)
### Before 

https://github.com/user-attachments/assets/b30c3395-b2ef-4dd7-86ce-8ccc01a09cbf

### After
#### `/settings`
https://github.com/user-attachments/assets/2b60b741-7b5c-44b8-adbb-bb40ae7c372f

#### `/settings/organization`
https://github.com/user-attachments/assets/71850815-b5a1-4f6b-b5b9-3677b605d8c3


#### UI 
https://github.com/user-attachments/assets/b87ac7ad-2d0e-4b65-9c3e-3a399a6abfbc

## Tests
<img width="1920" height="936" alt="image" src="https://github.com/user-attachments/assets/a137b753-68ad-453b-a758-6092d321ca09" />

<img width="293" height="98" alt="image" src="https://github.com/user-attachments/assets/ddcc93c7-c17e-42fa-b684-296969817855" />
