### PR TITLE
ui:main page button styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,11 +65,7 @@ export default async function HomePage() {
                   </p>
                 </div>
                 <div className="flex flex-col gap-2 min-[400px]:flex-row">
-                  <Button
-                    asChild
-                    size="lg"
-                    className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-white dark:text-black dark:hover:bg-zinc-100"
-                  >
+                  <Button asChild variant="shiny" size="shiny">
                     <Link href="/auth/signin">Get started - it&apos;s free</Link>
                   </Button>
                 </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -17,11 +17,14 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        shiny:
+          "relative bg-black dark:bg-white text-white dark:text-black border-2 border-orange-500/20 dark:border-orange-400/20 shadow-[0_8px_16px_-6px_rgba(251,113,133,0.3)] dark:shadow-[0_8px_16px_-6px_rgba(251,113,133,0.2)] shadow-[0_15px_30px_-6px_rgba(251,113,133,0.4),0_0px_30px_-6px_rgba(168,85,247,0.4)] dark:shadow-[0_15px_30px_-6px_rgba(251,113,133,0.3),0_0px_30px_-6px_rgba(168,85,247,0.3)] backdrop-blur-xs hover:rotate-[1deg] rounded-xl font-medium gap-4",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        shiny: "h-12 px-6 min-w-72 md:min-w-56",
         icon: "size-9",
       },
     },


### PR DESCRIPTION
Fixes #411 
Added a new variant in pre-existing button component for main page

Screenshot: 

Previous:
<img width="2804" height="1190" alt="image" src="https://github.com/user-attachments/assets/a5d0edd7-9dc4-4b93-8e9b-faccff9687bf" />



Updation:
<img width="1442" height="637" alt="Screenshot 2025-08-17 at 4 23 10 PM" src="https://github.com/user-attachments/assets/97018e0d-73da-4d07-9f30-96c09f224300" />

video 


https://github.com/user-attachments/assets/e3e1ec79-834e-4a8b-a6b2-e864249491ac







