### PR TITLE
fix: Board name does not update in dropdown menu after editing

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -568,9 +568,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         const { board } = await response.json();
         setBoard(board);
 
-        setAllBoards(prevBoards => 
-          prevBoards.map(b => b.id === board.id ? board : b)
-        );
+        setAllBoards((prevBoards) => prevBoards.map((b) => (b.id === board.id ? board : b)));
 
         setBoardSettings({
           name: board.name,


### PR DESCRIPTION
Fix: Board Name not Updated in Dropdown Menu After Editing

**Issue**
- When editing a board name through board settings, the dropdown menu continued to show the old board name.
- The board name change was saved to the database but the UI didn't reflect the update immediately.
- Users could think the name change didn't work, even though it was actually saved.

**Changes**
- Updated `handleUpdateBoardSettings` function.
- Added code to update the corresponding board in the `allBoards` array when board settings are saved.

**Result**
Board name changes now appear immediately in the dropdown menu without requiring a page refresh.


**Before**

https://github.com/user-attachments/assets/3d4fe878-71b1-45f4-bbc5-66988bf4145a


**After**

https://github.com/user-attachments/assets/dd3bb56a-59a1-4d5e-8a31-f405dc9f5913



Fixes https://github.com/antiwork/gumboard/issues/411