### PR TITLE
fix: add dark background to prevent white flash

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+html.dark {
+  background-color: #09090b;
+}
+
 /* Dotted background utility */
 .bg-dots {
   --dots-color: rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
## Description
Fixes an issue where a white background would appear when scrolling to the top of the page in dark mode.

### Changes Made
- Added `background-color: #09090b` (which equal to zinc-950) to the `html.dark` class to ensure consistent dark background
- This prevents the white flash that was visible at the top of the page in dark mode when scrolling top

Before
<img width="1470" height="956" alt="Screenshot 2025-08-18 at 11 34 47" src="https://github.com/user-attachments/assets/a2230e1c-1d44-4acd-86dd-cb97ff8759d6" />
<img width="2940" height="1912" alt="Screenshot 2025-08-18 at 11 34 41" src="https://github.com/user-attachments/assets/b712babc-7e94-42a7-8761-07816b53c62c" />


After

<img width="1470" height="956" alt="Screenshot 2025-08-18 at 11 34 58" src="https://github.com/user-attachments/assets/2a4f2669-3a6d-43b2-8303-35c8d6431c76" />
<img width="1470" height="956" alt="Screenshot 2025-08-18 at 11 35 01" src="https://github.com/user-attachments/assets/0caad9f6-4fb9-48ac-9816-aacf859d549a" />



Fixes: https://github.com/antiwork/gumboard/issues/411