### PR TITLE
fix: profile picture alignment on filter

### DIFF
--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -95,7 +95,13 @@ function FilterPopover({
                         "bg-blue-50  hover:bg-blue-50 text-sky-600 dark:text-zinc-200 dark:bg-zinc-800"
                     )}
                   >
-                    <User className="w-4 h-4 " />
+                    <Avatar className="w-6 h-6">
+                      <AvatarFallback>
+                        <div className="w-6 h-6 text-primary-foreground rounded-full flex items-center justify-center flex-shrink-0">
+                          <User className="w-4 h-4" />
+                        </div>
+                      </AvatarFallback>
+                    </Avatar>
                     <span className="font-medium">All authors</span>
                   </Button>
                   {authors.map((author) => (


### PR DESCRIPTION
## Description
Fixes inconsistent alignment of profile picture placeholders in the filter popover

### Changes Made
- Replaced the standalone `User` icon in the "All authors" button with an `Avatar` component structure
- Ensured both "All authors" and individual author items use the same `w-6 h-6` dimensions for proper visual alignment
        
Before
<img width="330" height="262" alt="image" src="https://github.com/user-attachments/assets/73760058-0e78-4057-a0d5-98d6d095c816" />

After
<img width="324" height="263" alt="image" src="https://github.com/user-attachments/assets/f59228e4-1eb7-47b5-8b49-66a701ea56e3" />

Fixes: https://github.com/antiwork/gumboard/issues/411