### PR TITLE
fix: add truncate to board card title

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -315,7 +315,10 @@ export default function Dashboard() {
                   >
                     <CardHeader>
                       <div className="grid grid-cols-[1fr_auto] items-start justify-between gap-2">
-                        <CardTitle className="text-lg dark:text-zinc-100 truncate" title={board.name}>
+                        <CardTitle
+                          className="text-lg dark:text-zinc-100 truncate"
+                          title={board.name}
+                        >
                           {board.name}
                         </CardTitle>
                         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 mt-0.5">


### PR DESCRIPTION

#428 got merged before the change was committed. This will fix it

https://github.com/antiwork/gumboard/pull/428#issuecomment-3192596105


Before:

<img width="1470" height="834" alt="before" src="https://github.com/user-attachments/assets/dd7d5061-1781-4a9f-bb3e-63cc305edd43" />

After:

<img width="1470" height="834" alt="truncated" src="https://github.com/user-attachments/assets/ce907207-54e4-422d-9e17-777476b1cf1a" />


