### PR TITLE
fix: set max-w to board picker in navbar to trunctate long text responsively

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -652,13 +652,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             </Link>
             <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700" />
             {/* Board Selector Dropdown */}
-            <div className="relative board-dropdown flex-1 mr-0 sm:flex-none">
+            <div className="relative board-dropdown flex-1 mr-0 sm:flex-none min-w-48 sm:max-w-64">
               <Button
                 onClick={() => setShowBoardDropdown(!showBoardDropdown)}
-                className={`flex items-center justify-between text-zinc-100 hover:text-foreground dark:hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600 dark:focus-visible:ring-sky-600 rounded-lg px-2 py-2 cursor-pointer w-full sm:w-auto`}
+                className="flex items-center justify-between text-zinc-100 hover:text-foreground dark:hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600 dark:focus-visible:ring-sky-600 rounded-lg px-2 py-2 cursor-pointer w-full"
               >
-                <div>
-                  <div className="text-sm font-semibold text-foreground dark:text-zinc-100">
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-foreground dark:text-zinc-100 truncate">
                     {boardId === "all-notes"
                       ? "All notes"
                       : boardId === "archive"


### PR DESCRIPTION
### Description

The board picker in navbar over-grows to a discomforting size on mobile and desktop causing an overflow in few cases on mobile.

This PR aims to address that issue by setting a max width of `256px` and min-width of `192px` for the the containing button 

### Before:

https://github.com/user-attachments/assets/b43a16bb-d75c-40f3-8420-1aa2780f8fa0

### After:

https://github.com/user-attachments/assets/809c4311-50e4-4baa-b1c7-47886846a55b

### Tests:

All passing

<img width="639" height="362" alt="specs" src="https://github.com/user-attachments/assets/9afe41c5-6c49-4fa0-80cc-b59507588ef9" />
