### PR TITLE
fix: enhance the ui of join page

### DIFF
--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -324,7 +324,10 @@ export default async function JoinPage({ params }: JoinPageProps) {
                   )}
                 </div>
               )}
-              <form action={autoCreateAccountAndJoin.bind(null, invite.token!)} className="space-y-5">
+              <form
+                action={autoCreateAccountAndJoin.bind(null, invite.token!)}
+                className="space-y-5"
+              >
                 <div className="space-y-2">
                   <Label
                     htmlFor="email"
@@ -426,9 +429,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
           <CardContent className="space-y-3">
             <div className="text-center space-y-3">
               <div className="space-y-1">
-                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                  Created by
-                </p>
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">Created by</p>
                 <p className="text-sm text-slate-600 dark:text-slate-400">
                   {invite.user.name || invite.user.email}
                 </p>
@@ -437,9 +438,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
                 <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
                   Organization info
                 </p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  {usageInfo}
-                </p>
+                <p className="text-sm text-slate-600 dark:text-slate-400">{usageInfo}</p>
               </div>
               {invite.expiresAt && (
                 <div className="pt-2">
@@ -450,11 +449,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
               )}
             </div>
             <form action={joinOrganization.bind(null, token)} className="pt-2">
-              <Button
-                type="submit"
-                className="w-full h-12 text-base font-medium"
-                size="lg"
-              >
+              <Button type="submit" className="w-full h-12 text-base font-medium" size="lg">
                 Join {invite.organization.name}
               </Button>
             </form>


### PR DESCRIPTION
Under #411 
When unauthenticated users try to join an organization
Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e918064a-65ec-45ff-bbda-02648274739e" />
Light Mode:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b8a5d7de-c4ae-49e6-be9e-0a827a5161d1" />



After:
<img width="1920" height="1080" alt="Screenshot from 2025-08-19 00-19-59" src="https://github.com/user-attachments/assets/0b3fd40f-8ddd-4b87-8cf5-28a916198ad6" />
Light Mode:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6bcb4661-8027-447b-8ed7-e06c203e5f96" />

When authenticated users try to join an organization
Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/091c2d26-2a34-4fc8-ab79-ba5831c33c95" />
Light Mode:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5ba06c41-bab4-4ea4-be2b-094eacd7a3af" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3b0e3194-cc39-4612-9a43-2839c746fba2" />
Light Mode:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/80344a9e-9708-409e-95b0-cafbfef02c6b" />


