### PR TITLE
fix: disorder in board navbar elements 

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -677,8 +677,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   return (
     <div className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots">
       <div>
-        <div className="mx-2 flex flex-wrap sm:flex-nowrap justify-between items-center h-auto sm:h-16 p-2 sm:p-0">
-          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 flex flex-wrap sm:flex-nowrap items-center sm:space-x-3 w-full sm:w-auto">
+        <div className="mx-0.5 sm:mx-5 grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-2 items-center h-auto sm:h-16 p-2 sm:p-0">
+          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 sm:w-fit grid grid-cols-[1fr_auto] sm:grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Company Name */}
             <Link href="/dashboard" className="flex-shrink-0 pl-1">
               <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-3">
@@ -686,9 +686,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 <BetaBadge />
               </h1>
             </Link>
-            <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700" />
+            <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700 hidden sm:block" />
             {/* Board Selector Dropdown */}
-            <div className="relative board-dropdown flex-1 mr-0 sm:flex-none min-w-48 sm:max-w-64">
+            <div className="relative board-dropdown min-w-32 sm:max-w-64 col-span-2 sm:col-span-1">
               <Button
                 onClick={() => setShowBoardDropdown(!showBoardDropdown)}
                 className="flex items-center justify-between text-zinc-100 hover:text-foreground dark:hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600 dark:focus-visible:ring-sky-600 rounded-lg px-2 py-2 cursor-pointer w-full"
@@ -777,54 +777,56 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 </div>
               )}
             </div>
-            <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700" />
+            <div className="h-6 w-px m-1.5 bg-zinc-100 dark:bg-zinc-700 hidden sm:block" />
 
             {/* Filter Popover */}
-            <div className="relative board-dropdown mr-1" data-slot="filter-popover">
-              <FilterPopover
-                startDate={dateRange.startDate}
-                endDate={dateRange.endDate}
-                onDateRangeChange={(startDate, endDate) => {
-                  const newDateRange = { startDate, endDate };
-                  setDateRange(newDateRange);
-                  updateURL(undefined, newDateRange);
-                }}
-                selectedAuthor={selectedAuthor}
-                authors={uniqueAuthors}
-                onAuthorChange={(authorId) => {
-                  setSelectedAuthor(authorId);
-                  updateURL(undefined, undefined, authorId);
-                }}
-                className="w-fit size-9"
-              />
+            <div className="flex flex-nowrap space-x-1">
+              <div className="relative board-dropdown" data-slot="filter-popover">
+                <FilterPopover
+                  startDate={dateRange.startDate}
+                  endDate={dateRange.endDate}
+                  onDateRangeChange={(startDate, endDate) => {
+                    const newDateRange = { startDate, endDate };
+                    setDateRange(newDateRange);
+                    updateURL(undefined, newDateRange);
+                  }}
+                  selectedAuthor={selectedAuthor}
+                  authors={uniqueAuthors}
+                  onAuthorChange={(authorId) => {
+                    setSelectedAuthor(authorId);
+                    updateURL(undefined, undefined, authorId);
+                  }}
+                  className="w-fit size-9"
+                />
+              </div>
+              {boardId !== "all-notes" && boardId !== "archive" && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setBoardSettings({
+                      name: board?.name || "",
+                      description: board?.description || "",
+                      isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
+                      sendSlackUpdates:
+                        (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+                    });
+                    setBoardSettingsDialog(true);
+                  }}
+                  aria-label="Board settings"
+                  title="Board settings"
+                  className="flex items-center size-9"
+                >
+                  <Settings className="size-4" />
+                </Button>
+              )}
             </div>
-            {boardId !== "all-notes" && boardId !== "archive" && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setBoardSettings({
-                    name: board?.name || "",
-                    description: board?.description || "",
-                    isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
-                    sendSlackUpdates:
-                      (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
-                  });
-                  setBoardSettingsDialog(true);
-                }}
-                aria-label="Board settings"
-                title="Board settings"
-                className="flex items-center size-9"
-              >
-                <Settings className="size-4" />
-              </Button>
-            )}
           </div>
 
           {/* Right side - Search, Add Note and User dropdown */}
-          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 flex flex-wrap sm:flex-nowrap items-center sm:space-x-3 w-full sm:w-auto gap-2 md:gap-0">
+          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 grid grid-cols-[1fr_auto] sm:grid-cols-[auto_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Search Box */}
-            <div className="relative flex-1 sm:flex-none min-w-[150px]">
+            <div className="relative h-9">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                 <Search className="h-4 w-4 text-muted-foreground dark:text-zinc-400" />
               </div>
@@ -836,7 +838,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 onChange={(e) => {
                   setSearchTerm(e.target.value);
                 }}
-                className="w-full sm:w-64 pl-10 pr-8 py-2 border border-zinc-100 dark:border-zinc-800 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-600 dark:focus:ring-sky-600 focus:border-transparent text-sm bg-background dark:bg-zinc-900 text-foreground dark:text-zinc-100 placeholder:text-muted-foreground dark:placeholder:text-zinc-400"
+                className="w-full pl-10 pr-8 py-2 border border-zinc-100 dark:border-zinc-800 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-600 dark:focus:ring-sky-600 focus:border-transparent text-sm bg-background dark:bg-zinc-900 text-foreground dark:text-zinc-100 placeholder:text-muted-foreground dark:placeholder:text-zinc-400"
               />
               {searchTerm && (
                 <Button
@@ -845,9 +847,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     setDebouncedSearchTerm("");
                     updateURL("");
                   }}
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground dark:text-zinc-400 hover:text-foreground dark:hover:text-zinc-100 cursor-pointer"
+                  className="absolute top-[5px] right-1 size-7 flex items-center text-muted-foreground dark:text-zinc-400 hover:text-white dark:hover:text-zinc-100 cursor-pointer bg-transparent"
                 >
-                  <X className="h-4 w-4" />
+                  <X className="h-4 w-4 " />
                 </Button>
               )}
             </div>
@@ -861,7 +863,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 }
               }}
               disabled={boardId === "archive"}
-              className="flex items-center justify-center text-white w-fit h-10 sm:w-auto sm:h-auto sm:space-x-2 bg-sky-600 hover:bg-sky-500 transition-all duration-200 cursor-pointer font-medium"
+              className="flex items-center justify-center text-white h-9 col-span-2 sm:col-span-1 sm:space-x-2 bg-sky-600 hover:bg-sky-500 transition-all duration-200 cursor-pointer font-medium"
             >
               <span>Add note</span>
             </Button>


### PR DESCRIPTION
### Description

Positioning of navbar elements was-off with no proper gaps and order with the right side over-flowing outside the screen on certain widths.

This PR resolves it by

1. Removing the fix width set to search box and allowing it to shrink by the size of the screen
2. Positions secondary action buttons to the top row for hand-held devices with full width applied to primary action

### Before

https://github.com/user-attachments/assets/370f5703-b10d-4278-8e5b-5d912f673a04


### After

https://github.com/user-attachments/assets/43176fe3-2c47-486c-83a6-b728f9f37f2f

### Tests:

All passing

<img width="1470" height="848" alt="specs" src="https://github.com/user-attachments/assets/b7e2309e-e4ef-42a0-b5e0-d0a9a01187c4" />
