### PR TITLE
feat: Add delete board feature

### DIFF
--- a/app/api/test/boards/cleanup/route.ts
+++ b/app/api/test/boards/cleanup/route.ts
@@ -6,10 +6,7 @@ export async function DELETE(request: Request) {
     const { name } = await request.json();
 
     if (!name) {
-      return NextResponse.json(
-        { error: "Board name is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Board name is required" }, { status: 400 });
     }
 
     // Delete test boards matching the name
@@ -22,9 +19,6 @@ export async function DELETE(request: Request) {
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error cleaning up test boards:", error);
-    return NextResponse.json(
-      { error: "Failed to clean up test boards" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to clean up test boards" }, { status: 500 });
   }
 }

--- a/app/api/test/boards/cleanup/route.ts
+++ b/app/api/test/boards/cleanup/route.ts
@@ -1,0 +1,30 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export async function DELETE(request: Request) {
+  try {
+    const { name } = await request.json();
+
+    if (!name) {
+      return NextResponse.json(
+        { error: "Board name is required" },
+        { status: 400 }
+      );
+    }
+
+    // Delete test boards matching the name
+    await db.board.deleteMany({
+      where: {
+        name: name,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error cleaning up test boards:", error);
+    return NextResponse.json(
+      { error: "Failed to clean up test boards" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -179,15 +179,15 @@ export default function Dashboard() {
 
   const confirmDelete = async () => {
     if (!boardToDelete) return;
-    
+
     setIsDeleting(true);
     try {
       const response = await fetch(`/api/boards/${boardToDelete}`, {
-        method: 'DELETE',
+        method: "DELETE",
       });
 
       if (response.ok) {
-        setBoards(boards.filter(board => board.id !== boardToDelete));
+        setBoards(boards.filter((board) => board.id !== boardToDelete));
       } else {
         const errorData = await response.json();
         setErrorDialog({
@@ -197,7 +197,7 @@ export default function Dashboard() {
         });
       }
     } catch (error) {
-      console.error('Error deleting board:', error);
+      console.error("Error deleting board:", error);
       setErrorDialog({
         open: true,
         title: "Error",
@@ -352,7 +352,6 @@ export default function Dashboard() {
               </Link>
 
               {boards.map((board) => (
-
                 <div key={board.id} className="relative group">
                   <Link href={`/boards/${board.id}`}>
                     <Card
@@ -369,7 +368,6 @@ export default function Dashboard() {
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
-
                       </div>
                       <CardHeader>
                         <div className="grid grid-cols-[1fr_auto] items-start justify-between gap-2 pr-6">
@@ -451,23 +449,16 @@ export default function Dashboard() {
               Delete Board
             </AlertDialogTitle>
             <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400">
-              Are you sure you want to delete this board? This action cannot be undone and all notes in this board will be permanently removed.
+              Are you sure you want to delete this board? This action cannot be undone and all notes
+              in this board will be permanently removed.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <Button 
-              variant="outline" 
-              onClick={cancelDelete}
-              disabled={isDeleting}
-            >
+            <Button variant="outline" onClick={cancelDelete} disabled={isDeleting}>
               Cancel
             </Button>
-            <Button 
-              variant="destructive" 
-              onClick={confirmDelete}
-              disabled={isDeleting}
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
+            <Button variant="destructive" onClick={confirmDelete} disabled={isDeleting}>
+              {isDeleting ? "Deleting..." : "Delete"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/tests/e2e/board-delete.spec.ts
+++ b/tests/e2e/board-delete.spec.ts
@@ -1,4 +1,3 @@
-// tests/e2e/board-delete.spec.ts
 import { test, expect } from "../fixtures/test-helpers";
 
 test.describe("Board Deletion", () => {
@@ -7,7 +6,6 @@ test.describe("Board Deletion", () => {
     testContext,
     testPrisma,
   }) => {
-    // Arrange — create a board owned by the logged-in test user
     const boardName = testContext.getBoardName("Delete Test Board");
     const board = await testPrisma.board.create({
       data: {
@@ -18,7 +16,6 @@ test.describe("Board Deletion", () => {
       },
     });
 
-    // Act — open dashboard, delete the card
     await authenticatedPage.goto("/dashboard");
     await authenticatedPage.waitForLoadState("networkidle");
 
@@ -35,10 +32,8 @@ test.describe("Board Deletion", () => {
     await expect(confirmDelete).toBeVisible({ timeout: 5_000 });
     await confirmDelete.click();
 
-    // Assert — card gone in UI
     await expect(boardCard).toHaveCount(0);
 
-    // And row gone in DB
     const dbAfter = await testPrisma.board.findUnique({ where: { id: board.id } });
     expect(dbAfter).toBeNull();
   });
@@ -48,7 +43,6 @@ test.describe("Board Deletion", () => {
     testContext,
     testPrisma,
   }) => {
-    // Arrange — create a board so we have a card
     const boardName = testContext.getBoardName("No-Permission Delete Board");
     const board = await testPrisma.board.create({
       data: {
@@ -72,7 +66,6 @@ test.describe("Board Deletion", () => {
       }
     });
 
-    // Act — attempt delete
     await authenticatedPage.goto("/dashboard");
     await authenticatedPage.waitForLoadState("networkidle");
 
@@ -88,7 +81,6 @@ test.describe("Board Deletion", () => {
     await expect(confirmDelete).toBeVisible({ timeout: 5_000 });
     await confirmDelete.click();
 
-    // Assert — error toast/message appears, DB row still exists
     await expect(authenticatedPage.getByText(/failed to delete board/i)).toBeVisible({
       timeout: 10_000,
     });

--- a/tests/e2e/board-delete.spec.ts
+++ b/tests/e2e/board-delete.spec.ts
@@ -1,0 +1,93 @@
+// tests/e2e/board-delete.spec.ts
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Board Deletion", () => {
+  test("should allow a user to delete a board", async ({ authenticatedPage, testContext, testPrisma }) => {
+    // Arrange — create a board owned by the logged-in test user
+    const boardName = testContext.getBoardName("Delete Test Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Board created for delete test"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // Act — open dashboard, delete the card
+    await authenticatedPage.goto("/dashboard");
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    const boardCard = authenticatedPage.locator(`[data-board-id="${board.id}"]`).first();
+    await expect(boardCard).toBeVisible({ timeout: 10_000 });
+
+    await boardCard.hover();
+
+    const deleteBtn = boardCard.getByRole("button", { name: /delete board/i });
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 });
+    await deleteBtn.click();
+
+    const confirmDelete = authenticatedPage.getByRole("button", { name: /^delete$/i });
+    await expect(confirmDelete).toBeVisible({ timeout: 5_000 });
+    await confirmDelete.click();
+
+    // Assert — card gone in UI
+    await expect(boardCard).toHaveCount(0);
+
+    // And row gone in DB
+    const dbAfter = await testPrisma.board.findUnique({ where: { id: board.id } });
+    expect(dbAfter).toBeNull();
+  });
+
+  test("should show error when trying to delete a board without permission", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Arrange — create a board so we have a card
+    const boardName = testContext.getBoardName("No-Permission Delete Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Board used to simulate 403 on delete"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // Simulate backend denying deletion
+    await authenticatedPage.route("/api/boards/*", async (route) => {
+      if (route.request().method() === "DELETE") {
+        await route.fulfill({
+          status: 403,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Access denied" }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Act — attempt delete
+    await authenticatedPage.goto("/dashboard");
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    const boardCard = authenticatedPage.locator(`[data-board-id="${board.id}"]`).first();
+    await expect(boardCard).toBeVisible({ timeout: 10_000 });
+    await boardCard.hover();
+
+    const deleteBtn = boardCard.getByRole("button", { name: /delete board/i });
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 });
+    await deleteBtn.click();
+
+    const confirmDelete = authenticatedPage.getByRole("button", { name: /^delete$/i });
+    await expect(confirmDelete).toBeVisible({ timeout: 5_000 });
+    await confirmDelete.click();
+
+    // Assert — error toast/message appears, DB row still exists
+    await expect(authenticatedPage.getByText(/failed to delete board/i)).toBeVisible({ timeout: 10_000 });
+
+    const stillThere = await testPrisma.board.findUnique({ where: { id: board.id } });
+    expect(stillThere).not.toBeNull();
+  });
+});

--- a/tests/e2e/board-delete.spec.ts
+++ b/tests/e2e/board-delete.spec.ts
@@ -2,7 +2,11 @@
 import { test, expect } from "../fixtures/test-helpers";
 
 test.describe("Board Deletion", () => {
-  test("should allow a user to delete a board", async ({ authenticatedPage, testContext, testPrisma }) => {
+  test("should allow a user to delete a board", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
     // Arrange — create a board owned by the logged-in test user
     const boardName = testContext.getBoardName("Delete Test Board");
     const board = await testPrisma.board.create({
@@ -85,7 +89,9 @@ test.describe("Board Deletion", () => {
     await confirmDelete.click();
 
     // Assert — error toast/message appears, DB row still exists
-    await expect(authenticatedPage.getByText(/failed to delete board/i)).toBeVisible({ timeout: 10_000 });
+    await expect(authenticatedPage.getByText(/failed to delete board/i)).toBeVisible({
+      timeout: 10_000,
+    });
 
     const stillThere = await testPrisma.board.findUnique({ where: { id: board.id } });
     expect(stillThere).not.toBeNull();


### PR DESCRIPTION
### Delete Board Feature

This PR adds the ability to delete boards in Gumboard. When a board is deleted:

- The board is permanently removed from the dashboard
- All notes within that board are automatically deleted
- A confirmation dialog prevents accidental deletions
- Only board creators and admins can delete boards

The change helps users clean up old or unused boards while maintaining data integrity by removing associated notes.

### Screen Recording 

https://github.com/user-attachments/assets/75748347-a81d-4cef-b36d-fedc4d458547

