### PR TITLE
fix(ui): reduce per-note blank space and height

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -346,7 +346,7 @@ export function Note({
         ...style,
       }}
     >
-      <div className="flex items-start justify-between mb-2 flex-shrink-0">
+      <div className="flex items-start justify-between mb-1 flex-shrink-0">
         <div className="flex items-center space-x-2">
           <Avatar className="h-7 w-7 border-2 border-white dark:border-zinc-800">
             <AvatarFallback className="bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 text-sm font-semibold">
@@ -386,7 +386,7 @@ export function Note({
                       e.stopPropagation();
                       onCopy?.(note);
                     }}
-                    className="p-1 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 rounded"
+                    className="p-0.5 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 rounded"
                     variant="ghost"
                     size="icon"
                   >
@@ -405,7 +405,7 @@ export function Note({
                       e.stopPropagation();
                       onDelete?.(note.id);
                     }}
-                    className="p-1 text-gray-600 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 rounded"
+                    className="p-0.5 text-gray-600 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 rounded"
                     variant="ghost"
                     size="icon"
                   >
@@ -427,7 +427,7 @@ export function Note({
                       e.stopPropagation();
                       onArchive(note.id);
                     }}
-                    className="p-1 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 rounded"
+                    className="p-0.5 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 rounded"
                     variant="ghost"
                     size="icon"
                     aria-label="Archive note"
@@ -450,7 +450,7 @@ export function Note({
                       e.stopPropagation();
                       onUnarchive(note.id);
                     }}
-                    className="p-1 text-gray-600 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-400 rounded"
+                    className="p-0.5 text-gray-600 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-400 rounded"
                     variant="ghost"
                     size="icon"
                     aria-label="Unarchive note"
@@ -478,7 +478,7 @@ export function Note({
               }
             }}
           >
-            <DraggableContainer className="space-y-1">
+            <DraggableContainer className="space-y-0.5">
               {note.checklistItems?.map((item) => (
                 <DraggableItem key={item.id} id={item.id} disabled={!canEdit}>
                   <ChecklistItemComponent

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -29,15 +29,15 @@ export function getResponsiveConfig() {
   const width = window.innerWidth;
 
   if (width >= 1920) {
-    return { noteWidth: 340, gridGap: 24, containerPadding: 32, notePadding: 18 };
+    return { noteWidth: 340, gridGap: 24, containerPadding: 32, notePadding: 16 };
   } else if (width >= 1200) {
-    return { noteWidth: 320, gridGap: 20, containerPadding: 24, notePadding: 16 };
+    return { noteWidth: 320, gridGap: 20, containerPadding: 24, notePadding: 14 };
   } else if (width >= 768) {
-    return { noteWidth: 300, gridGap: 16, containerPadding: 20, notePadding: 16 };
+    return { noteWidth: 300, gridGap: 16, containerPadding: 20, notePadding: 14 };
   } else if (width >= 600) {
-    return { noteWidth: 280, gridGap: 16, containerPadding: 16, notePadding: 14 };
+    return { noteWidth: 280, gridGap: 16, containerPadding: 16, notePadding: 12 };
   } else {
-    return { noteWidth: 260, gridGap: 12, containerPadding: 12, notePadding: 12 };
+    return { noteWidth: 260, gridGap: 12, containerPadding: 12, notePadding: 10 };
   }
 }
 


### PR DESCRIPTION
**Fixes** #512 

- Trims roughly 28–36px from note view, preserving comfortable spacing for real content and fitting more notes per viewport.

### **Before**
<img width="1920" height="869" alt="chrome_2SDXwBMukR" src="https://github.com/user-attachments/assets/6480b6c1-bf48-4a38-ab17-195fae27a7bb" />


### **After**

<img width="1920" height="869" alt="chrome_9hTx3SC3pl" src="https://github.com/user-attachments/assets/2047da8b-ad95-4f41-a33e-390a574e844f" />



