### PR TITLE
Fix: Prevent note-card overflow & overlap (#507)

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -27,10 +27,7 @@ import type { Note, Board, User } from "@/components/note";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { toast } from "sonner";
 import { useUser } from "@/app/contexts/UserContext";
-import {
-  getUniqueAuthors,
-  filterAndSortNotes,
-} from "@/lib/utils";
+import { getUniqueAuthors, filterAndSortNotes } from "@/lib/utils";
 import { BoardPageSkeleton } from "@/components/board-skeleton";
 
 export default function BoardPage({ params }: { params: Promise<{ id: string }> }) {
@@ -210,8 +207,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   // Removed debounce cleanup effect; editing is scoped to Note
 
-
-
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearchTerm(searchTerm);
@@ -229,7 +224,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     () => filterAndSortNotes(notes, debouncedSearchTerm, dateRange, selectedAuthor, user),
     [notes, debouncedSearchTerm, dateRange, selectedAuthor, user]
   );
-
 
   const fetchBoardData = async () => {
     try {
@@ -829,10 +823,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       </div>
 
       {/* Board Area */}
-      <div
-        ref={boardRef}
-        className="w-full min-h-[calc(100vh-64px)] p-3 md:p-5"
-      >
+      <div ref={boardRef} className="w-full min-h-[calc(100vh-64px)] p-3 md:p-5">
         {/* Notes Grid */}
         <div className="grid gap-4 auto-fit-notes">
           {filteredNotes.map((note) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,32 @@ html.dark {
 .dark input[type="date"]::-webkit-calendar-picker-indicator {
   filter: invert(1);
 }
+
+/* Responsive notes grid */
+.auto-fit-notes {
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+@media (min-width: 640px) {
+  .auto-fit-notes {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .auto-fit-notes {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .auto-fit-notes {
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .auto-fit-notes {
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  }
+}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -337,7 +337,7 @@ export function Note({
   return (
     <div
       className={cn(
-        "rounded-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border",
+        "rounded-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border min-h-[200px] h-fit",
         className
       )}
       data-testid="note-card"
@@ -467,8 +467,8 @@ export function Note({
         </div>
       </div>
 
-      <div className="flex flex-col">
-        <div className="overflow-y-auto space-y-1">
+      <div className="flex flex-col flex-1">
+        <div className="space-y-1 flex-1">
           {/* Checklist Items */}
           <DraggableRoot
             items={note.checklistItems ?? []}

--- a/tests/e2e/note-card-layout.spec.ts
+++ b/tests/e2e/note-card-layout.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+// Test to ensure checklist item editing doesn't overflow note card
+// verifying fix from "enhance boards note card layout flow" feature.
+test.describe("Note card layout", () => {
+  test("keeps checklist items within card when editing", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create board and note
+    const boardName = testContext.getBoardName("Test Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Board for layout test"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    const note = await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        boardId: board.id,
+        createdBy: testContext.userId,
+      },
+    });
+
+    const itemId = testContext.prefix("item-1");
+    const originalContent = testContext.prefix("Original item");
+
+    await testPrisma.checklistItem.create({
+      data: {
+        id: itemId,
+        content: originalContent,
+        checked: false,
+        order: 0,
+        noteId: note.id,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Edit item with long content that would overflow if card height fixed
+    const longContent = testContext.prefix("Long content ".repeat(20));
+    
+    await authenticatedPage.getByText(originalContent).click();
+    const editInput = authenticatedPage.getByTestId(itemId).getByRole("textbox");
+    await expect(editInput).toBeVisible();
+
+    const saveEditResponse = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes(`/api/boards/${board.id}/notes/${note.id}`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
+    await editInput.fill(longContent);
+    await authenticatedPage.click("body");
+    await saveEditResponse;
+
+    // Ensure edited content is visible
+    await expect(authenticatedPage.getByText(longContent)).toBeVisible();
+
+    // Verify note card height expands to fit content (no overflow)
+    const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
+    const hasOverflow = await noteCard.evaluate((el) => el.scrollHeight > el.clientHeight);
+    expect(hasOverflow).toBe(false);
+  });
+});
+

--- a/tests/e2e/note-card-layout.spec.ts
+++ b/tests/e2e/note-card-layout.spec.ts
@@ -44,13 +44,14 @@ test.describe("Note card layout", () => {
 
     // Edit item with long content that would overflow if card height fixed
     const longContent = testContext.prefix("Long content ".repeat(20));
-    
+
     await authenticatedPage.getByText(originalContent).click();
     const editInput = authenticatedPage.getByTestId(itemId).getByRole("textbox");
     await expect(editInput).toBeVisible();
 
     const saveEditResponse = authenticatedPage.waitForResponse(
-      (resp) => resp.url().includes(`/api/boards/${board.id}/notes/${note.id}`) &&
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes/${note.id}`) &&
         resp.request().method() === "PUT" &&
         resp.ok()
     );
@@ -68,4 +69,3 @@ test.describe("Note card layout", () => {
     expect(hasOverflow).toBe(false);
   });
 });
-


### PR DESCRIPTION
fixes #507 

This PR introduces a cleaner, CSS-first approach to layout and enhances test coverage with a focused E2E check to prevent regressions.

1. Layout Overhaul

Replaced custom JS-based absolute positioning with a responsive CSS Grid (auto-fit-notes).

Removed calculateGridLayout, calculateMobileLayout, resize listeners, and related state management.

Cards now scale naturally (min-h-[200px] h-fit) without overlapping.

2. NoteCard Enhancements

Refactored card internals to use Flexbox, ensuring checklist items expand vertically as needed.

Eliminated fixed height calculations—overflow is handled gracefully by design.

E2E Test:
Added tests/e2e/note-card-layout.spec.ts – one concise scenario:
Edit a checklist item with very long content.
Assert card shows the text and scrollHeight === clientHeight (no overflow).

<img width="428" height="116" alt="Screenshot 2025-08-19 112634" src="https://github.com/user-attachments/assets/aed2bd84-39cd-42c6-9354-bb482358c1c7" />

after fix :

https://github.com/user-attachments/assets/cb51ce82-c12d-4249-808a-b47decb68968

