### PR TITLE
fix(ui): note checklist darkmode styles

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -120,7 +120,7 @@ export function ChecklistItem({
         onChange={(e) => onEditContentChange?.(e.target.value)}
         disabled={readonly}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
+          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 resize-none overflow-hidden outline-none",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -360,7 +360,7 @@ export function Note({
             />
           </Avatar>
           <div className="flex flex-col">
-            <span className="text-sm font-bold text-gray-700 dark:text-zinc-100 truncate max-w-20">
+            <span className="text-sm font-bold text-gray-700 dark:text-zinc-700 truncate max-w-20">
               {note.user.name ? note.user.name.split(" ")[0] : note.user.email.split("@")[0]}
             </span>
             <div className="flex flex-col">

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -360,7 +360,7 @@ export function Note({
             />
           </Avatar>
           <div className="flex flex-col">
-            <span className="text-sm font-bold text-gray-700 dark:text-zinc-700 truncate max-w-20">
+            <span className="text-sm font-bold text-gray-700 truncate max-w-20">
               {note.user.name ? note.user.name.split(" ")[0] : note.user.email.split("@")[0]}
             </span>
             <div className="flex flex-col">


### PR DESCRIPTION
# Description
Checklist item and note author name were too light for dark mode 

Before
<img width="3072" height="1728" alt="Screenshot from 2025-08-19 11-56-23" src="https://github.com/user-attachments/assets/4f8b6b7d-43e5-475e-be21-390c8c141abd" />

After
<img width="3072" height="1728" alt="Screenshot from 2025-08-19 11-56-58" src="https://github.com/user-attachments/assets/e41915e4-4d29-4281-ac06-60f63e5015e1" />
