### PR TITLE
fix: Resolve text overflow in note cards

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -28,11 +28,7 @@ import { useTheme } from "next-themes";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { toast } from "sonner";
 import { useUser } from "@/app/contexts/UserContext";
-import {
-  getResponsiveConfig,
-  getUniqueAuthors,
-  filterAndSortNotes,
-} from "@/lib/utils";
+import { getResponsiveConfig, getUniqueAuthors, filterAndSortNotes } from "@/lib/utils";
 import { BoardPageSkeleton } from "@/components/board-skeleton";
 
 export default function BoardPage({ params }: { params: Promise<{ id: string }> }) {

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -100,7 +100,7 @@ export function ChecklistItem({
   return (
     <div
       className={cn(
-        "flex items-start group/item rounded gap-2 transition-all duration-200",
+        "flex items-start group/item rounded gap-2 transition-all duration-200 w-full overflow-hidden",
         className
       )}
       // To avoid flaky test locators
@@ -120,7 +120,7 @@ export function ChecklistItem({
         onChange={(e) => onEditContentChange?.(e.target.value)}
         disabled={readonly}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
+          "flex-1 min-w-0 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none outline-none break-all whitespace-pre-wrap",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}
@@ -139,7 +139,7 @@ export function ChecklistItem({
           }
         }}
         rows={1}
-        style={{ height: "auto" }}
+        style={{ height: "auto", overflowWrap: "break-word" }}
         onInput={(e) => {
           const target = e.target as HTMLTextAreaElement;
           const currentContent = target.value;

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -468,7 +468,7 @@ export function Note({
       </div>
 
       <div className="flex flex-col">
-        <div className="overflow-y-auto space-y-1">
+        <div className="space-y-1">
           {/* Checklist Items */}
           <DraggableRoot
             items={note.checklistItems ?? []}

--- a/tests/e2e/text-overflow.spec.ts
+++ b/tests/e2e/text-overflow.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Text Overflow and Card Expansion", () => {
+  test("should handle long text without overflow and expand card height", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const boardName = testContext.getBoardName("Text Overflow Test Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Test board for text overflow"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // Create a note with long text content
+    const longText = testContext.prefix(
+      "This is a very long text that should display properly without causing horizontal overflow. " +
+      "It contains multiple sentences to test the text display behavior. " +
+      "The card should expand vertically to accommodate all this content without showing any scrollbars. " +
+      "We want to ensure that users can read all the text comfortably without having to scroll within the card."
+    );
+
+    const note = await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        boardId: board.id,
+        createdBy: testContext.userId,
+        checklistItems: {
+          create: [
+            {
+              id: testContext.prefix("item-1"),
+              content: longText,
+              checked: false,
+              order: 0,
+            },
+            {
+              id: testContext.prefix("item-2"),
+              content: testContext.prefix("Short item"),
+              checked: false,
+              order: 1,
+            },
+            {
+              id: testContext.prefix("item-3"),
+              content: testContext.prefix(
+                "Another long item to ensure the card expands properly with multiple long items"
+              ),
+              checked: false,
+              order: 2,
+            },
+          ],
+        },
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Wait for the note card to be visible
+    const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
+    await expect(noteCard).toBeVisible();
+
+    // Check that the long text is visible
+    await expect(authenticatedPage.getByText(longText)).toBeVisible();
+
+    // Get the note card's computed styles
+    const noteCardBox = await noteCard.boundingBox();
+    expect(noteCardBox).toBeTruthy();
+
+    // Verify that the card has expanded to fit content (should be taller than a minimal height)
+    expect(noteCardBox!.height).toBeGreaterThan(200);
+
+    // Check that there's no overflow on the card
+    const overflow = await noteCard.evaluate((el) => {
+      const styles = window.getComputedStyle(el);
+      return {
+        overflowY: styles.overflowY,
+        overflowX: styles.overflowX,
+      };
+    });
+
+    // The card should not have scroll overflow
+    expect(overflow.overflowY).not.toBe('scroll');
+    expect(overflow.overflowY).not.toBe('auto');
+    expect(overflow.overflowX).not.toBe('scroll');
+    expect(overflow.overflowX).not.toBe('auto');
+
+    // Verify all items are visible without scrolling
+    await expect(authenticatedPage.getByText(testContext.prefix("Short item"))).toBeVisible();
+    await expect(
+      authenticatedPage.getByText(
+        testContext.prefix("Another long item to ensure the card expands properly with multiple long items")
+      )
+    ).toBeVisible();
+  });
+
+  test("should expand card height when typing long text", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const boardName = testContext.getBoardName("Dynamic Expansion Test Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Test board for dynamic card expansion"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    // Create a new note
+    const createNoteResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes`) &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201
+    );
+    await authenticatedPage.click('button:has-text("Add note")');
+    await createNoteResponse;
+
+    // Get the note card
+    const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
+    await expect(noteCard).toBeVisible();
+
+    // Get initial height
+    const initialBox = await noteCard.boundingBox();
+    expect(initialBox).toBeTruthy();
+    const initialHeight = initialBox!.height;
+
+    // Type long text into the new item input
+    const newItemInput = authenticatedPage.locator("textarea").first();
+    await expect(newItemInput).toBeVisible();
+
+    const longText = testContext.prefix(
+      "This is a very long text that I'm typing to test dynamic expansion. " +
+      "As I type more and more text, the card should grow taller. " +
+      "The height should adjust automatically without any scrollbars appearing. " +
+      "This ensures a smooth user experience when entering long checklist items."
+    );
+
+    // Type the long text
+    await newItemInput.fill(longText);
+
+    // Wait a moment for the card to adjust
+    await authenticatedPage.waitForTimeout(500);
+
+    // Get the new height
+    const expandedBox = await noteCard.boundingBox();
+    expect(expandedBox).toBeTruthy();
+    const expandedHeight = expandedBox!.height;
+
+    // Verify the card has expanded
+    expect(expandedHeight).toBeGreaterThan(initialHeight);
+
+    // Save the item
+    const addItemResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes/`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+    await newItemInput.blur();
+    await addItemResponse;
+
+    // Verify the text is still visible after saving
+    await expect(authenticatedPage.getByText(longText)).toBeVisible();
+
+    // Verify the card still has no overflow
+    const overflow = await noteCard.evaluate((el) => {
+      const styles = window.getComputedStyle(el);
+      return {
+        overflowY: styles.overflowY,
+        overflowX: styles.overflowX,
+      };
+    });
+
+    expect(overflow.overflowY).not.toBe('scroll');
+    expect(overflow.overflowY).not.toBe('auto');
+    expect(overflow.overflowX).not.toBe('scroll');
+    expect(overflow.overflowX).not.toBe('auto');
+  });
+});

--- a/tests/e2e/text-overflow.spec.ts
+++ b/tests/e2e/text-overflow.spec.ts
@@ -25,8 +25,9 @@ test.describe("Text Overflow and Card Expansion", () => {
       },
     });
 
-    const longTextWithoutSpaces = "sihshshsihishsihishsihishsihishsihishsihwosjowsjwsojwojowjsojowsjowsjowsjowjsojowsjoxjsoxjsoxjosxjosxjosxjosxjosjosxjosxjosxjosjosoxjosojsowjsowjsowjsjowsjowjsjwsojw";
-    
+    const longTextWithoutSpaces =
+      "sihshshsihishsihishsihishsihishsihishsihwosjowsjwsojwojowjsojowsjowsjowsjowjsojowsjoxjsoxjsoxjosxjosxjosxjosxjosjosxjosxjosxjosjosoxjosojsowjsowjsowjsjowsjowjsjwsojw";
+
     await testPrisma.checklistItem.create({
       data: {
         id: testContext.prefix("item-1"),
@@ -45,16 +46,19 @@ test.describe("Text Overflow and Card Expansion", () => {
     await expect(noteCard).toBeVisible();
 
     // Check that the note card is using grid layout (parent container)
-    const boardArea = authenticatedPage.locator('.grid').filter({
-      has: authenticatedPage.locator('[data-testid="note-card"]')
-    }).first();
+    const boardArea = authenticatedPage
+      .locator(".grid")
+      .filter({
+        has: authenticatedPage.locator('[data-testid="note-card"]'),
+      })
+      .first();
     await expect(boardArea).toBeVisible();
 
     // Verify the note has h-fit class for dynamic height
     await expect(noteCard).toHaveClass(/h-fit/);
 
     // Get the textarea with long text
-    const textarea = noteCard.locator('textarea').filter({ hasText: longTextWithoutSpaces });
+    const textarea = noteCard.locator("textarea").filter({ hasText: longTextWithoutSpaces });
     await expect(textarea).toBeVisible();
 
     // Verify text wrapping classes are applied
@@ -65,7 +69,7 @@ test.describe("Text Overflow and Card Expansion", () => {
     // Verify no overflow on the textarea
     const textareaBox = await textarea.boundingBox();
     const noteCardBox = await noteCard.boundingBox();
-    
+
     // The textarea should be within the note card bounds
     expect(textareaBox).toBeTruthy();
     expect(noteCardBox).toBeTruthy();
@@ -111,20 +115,20 @@ test.describe("Text Overflow and Card Expansion", () => {
     await authenticatedPage.waitForSelector('[data-testid="note-card"]');
 
     const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
-    
+
     // Get initial height
     const initialBox = await noteCard.boundingBox();
     expect(initialBox).toBeTruthy();
     const initialHeight = initialBox?.height || 0;
 
     // Find and interact with the textarea
-    const textarea = noteCard.locator('textarea').first();
+    const textarea = noteCard.locator("textarea").first();
     await expect(textarea).toBeVisible();
-    
+
     // Click to edit and add long text
     await textarea.click();
     await textarea.selectText();
-    
+
     // Type very long text that should cause expansion
     const veryLongText = "This is a very long text that will cause the card to expand. ".repeat(20);
     await textarea.type(veryLongText);
@@ -140,5 +144,4 @@ test.describe("Text Overflow and Card Expansion", () => {
     // Verify that the card has expanded
     expect(expandedHeight).toBeGreaterThan(initialHeight);
   });
-
 });

--- a/tests/e2e/text-overflow.spec.ts
+++ b/tests/e2e/text-overflow.spec.ts
@@ -19,9 +19,9 @@ test.describe("Text Overflow and Card Expansion", () => {
     // Create a note with long text content
     const longText = testContext.prefix(
       "This is a very long text that should display properly without causing horizontal overflow. " +
-      "It contains multiple sentences to test the text display behavior. " +
-      "The card should expand vertically to accommodate all this content without showing any scrollbars. " +
-      "We want to ensure that users can read all the text comfortably without having to scroll within the card."
+        "It contains multiple sentences to test the text display behavior. " +
+        "The card should expand vertically to accommodate all this content without showing any scrollbars. " +
+        "We want to ensure that users can read all the text comfortably without having to scroll within the card."
     );
 
     const note = await testPrisma.note.create({
@@ -82,16 +82,18 @@ test.describe("Text Overflow and Card Expansion", () => {
     });
 
     // The card should not have scroll overflow
-    expect(overflow.overflowY).not.toBe('scroll');
-    expect(overflow.overflowY).not.toBe('auto');
-    expect(overflow.overflowX).not.toBe('scroll');
-    expect(overflow.overflowX).not.toBe('auto');
+    expect(overflow.overflowY).not.toBe("scroll");
+    expect(overflow.overflowY).not.toBe("auto");
+    expect(overflow.overflowX).not.toBe("scroll");
+    expect(overflow.overflowX).not.toBe("auto");
 
     // Verify all items are visible without scrolling
     await expect(authenticatedPage.getByText(testContext.prefix("Short item"))).toBeVisible();
     await expect(
       authenticatedPage.getByText(
-        testContext.prefix("Another long item to ensure the card expands properly with multiple long items")
+        testContext.prefix(
+          "Another long item to ensure the card expands properly with multiple long items"
+        )
       )
     ).toBeVisible();
   });
@@ -138,9 +140,9 @@ test.describe("Text Overflow and Card Expansion", () => {
 
     const longText = testContext.prefix(
       "This is a very long text that I'm typing to test dynamic expansion. " +
-      "As I type more and more text, the card should grow taller. " +
-      "The height should adjust automatically without any scrollbars appearing. " +
-      "This ensures a smooth user experience when entering long checklist items."
+        "As I type more and more text, the card should grow taller. " +
+        "The height should adjust automatically without any scrollbars appearing. " +
+        "This ensures a smooth user experience when entering long checklist items."
     );
 
     // Type the long text
@@ -179,9 +181,9 @@ test.describe("Text Overflow and Card Expansion", () => {
       };
     });
 
-    expect(overflow.overflowY).not.toBe('scroll');
-    expect(overflow.overflowY).not.toBe('auto');
-    expect(overflow.overflowX).not.toBe('scroll');
-    expect(overflow.overflowX).not.toBe('auto');
+    expect(overflow.overflowY).not.toBe("scroll");
+    expect(overflow.overflowY).not.toBe("auto");
+    expect(overflow.overflowX).not.toBe("scroll");
+    expect(overflow.overflowX).not.toBe("auto");
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes the text overflow and unwanted scrollbar issues in note cards by implementing a CSS Grid-based layout that allows cards to expand vertically to accommodate content.

Fixes #507 and #512

## Problem
- Long text in checklist items was being cut off or causing overflow
- Cards had a fixed height that didn't adapt to content length
- Poor user experience when working with notes containing multiple items or long text

## Solution
Implemented a clean CSS Grid layout that:
- Removes fixed heights from note cards, allowing them to expand naturally
- Uses `grid-template-rows: masonry` for optimal card placement (when supported)
- Falls back to `grid-auto-rows: min-content` for browsers without masonry support
- Eliminates all overflow issues by letting content determine card height

## Changes Made

### Core Fix
- **`components/note-card.tsx`**: Removed `max-h-[400px] overflow-y-auto` classes that were causing scrollbars
- **`components/boards/note-list.tsx`**: Replaced Flexbox layout with CSS Grid for better content-aware sizing

### Code Cleanup
Removed unnecessary layout calculation code that's no longer needed with CSS Grid:
- Removed `calculateGridLayout` and `calculateMobileLayout` functions and imports
- Removed `isMobile` state and responsive resize effect
- Removed `addingChecklistItem` state used for layout recalculation
- Removed `boardHeight` calculation variable
- Simplified component by removing layout-related JavaScript complexity

### Tests
- Added comprehensive E2E tests in `tests/e2e/text-overflow.spec.ts` to verify:
  - Cards expand vertically with long content without showing scrollbars
  - Dynamic height adjustment when users type long text
  - Proper text wrapping without horizontal overflow

## Testing
- ✅ All existing tests pass
- ✅ New text overflow tests pass
- ✅ Manual testing confirms smooth UX with no scrollbars in cards
- ✅ Tested with various content lengths and multiple checklist items

<img width="1019" height="253" alt="Screenshot 2025-08-19 at 1 07 32 PM" src="https://github.com/user-attachments/assets/73c4993d-9a3c-4b0f-9d4b-c9dad8f47364" />

## Screenshots
Before

https://github.com/user-attachments/assets/80021536-14cf-4e9a-b5c1-6f439196fa8d

After


https://github.com/user-attachments/assets/6d79bde8-e8c6-434d-bd83-18e979a3f518

## Breaking Changes
None - this is a pure visual/UX improvement with no API or data model changes.