### PR TITLE
fix: Fix card layout compression on checklist item changes

### DIFF
--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -356,7 +356,8 @@ export function StickyNotesDemo() {
                 className="mb-4 break-inside-avoid"
                 variants={itemVariants}
                 exit="exit"
-                layout
+                layout="position"
+                layoutId={note.id}
               >
                 <div className="pb-4">
                   <NoteComponent


### PR DESCRIPTION
## Problem
Cards were compressing/shifting when adding or removing checklist items, causing a poor user experience.

Fix #514

## Solution
Updated Framer Motion configuration to use `layout="position"` which only animates position changes, preventing unwanted size animations during checklist updates.

## Changes
- Added `layout="position"` prop to note cards
- Added `layoutId` for stable animation tracking

### Screen recordings 

**Before**

https://github.com/user-attachments/assets/74d1f47d-ac22-443f-a115-3bab25e2c151

**After**

https://github.com/user-attachments/assets/dea14332-ee0d-415c-bfb6-52439400a0bc

