### PR TITLE
fix: correct extra spacing in Send Invite button

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -652,7 +652,7 @@ export default function OrganizationSettingsPage() {
                 "Inviting..."
               ) : (
                 <>
-                  <span className="hidden lg:inline">Send</span>Invite
+                  <span className="hidden lg:inline">Send Invite</span>
                 </>
               )}
             </Button>


### PR DESCRIPTION
- Before:

<img width="1283" height="456" alt="image" src="https://github.com/user-attachments/assets/8cbf33a0-4b17-412d-a843-69b21d537295" />


- After:

<img width="1364" height="453" alt="image" src="https://github.com/user-attachments/assets/ec45fb06-5605-4b00-b6a4-e872af371379" />

ref: #411 