### PR TITLE
fix: implement content-first search to exclude author names from results

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -203,10 +203,9 @@ export function filterAndSortNotes(
   if (searchTerm.trim()) {
     const search = searchTerm.toLowerCase();
     filteredNotes = filteredNotes.filter((note) => {
-      const authorName = (note.user.name || note.user.email).toLowerCase();
       const checklistContent =
         note.checklistItems?.map((item) => item.content.toLowerCase()).join(" ") || "";
-      return authorName.includes(search) || checklistContent.includes(search);
+      return checklistContent.includes(search);
     });
   }
 


### PR DESCRIPTION
**Problem:** Search was showing notes based on author names, not just content. 
When searching for "ansh", it would show ALL notes by user "Ansh" even if 
the note content was irrelevant (e.g., note with task "dilli").

- **Before:** Search "ansh" showed notes by "Ansh" + notes with "ansh" content

<img width="1920" height="1080" alt="Screenshot From 2025-08-19 16-40-33" src="https://github.com/user-attachments/assets/96952bd2-d1a9-44a1-b535-a5842d52403b" />

- **After:** Search "ansh" only shows notes with "ansh" in task content
<img width="1914" height="990" alt="Screenshot From 2025-08-19 17-00-05" src="https://github.com/user-attachments/assets/2e2b9d28-969d-46b8-b89d-db2968ded970" />


<img width="967" height="451" alt="Screenshot From 2025-08-19 17-01-40" src="https://github.com/user-attachments/assets/2f96934d-3bdb-472d-9346-071c72d09d09" />

ref: #411 
