### PR TITLE
fix: search ux when adding a new note

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -397,7 +397,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         const { note } = await response.json();
         setNotes((prev) => [...prev, note]);
         setAddingChecklistItem(note.id);
-        if (searchTerm || dateRange.startDate || dateRange.endDate || selectedAuthor) {
+        if (searchTerm.trim() || dateRange.startDate || dateRange.endDate || selectedAuthor) {
           setSearchTerm("");
           setDebouncedSearchTerm("");
           setDateRange({ startDate: null, endDate: null });

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -89,37 +89,40 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   }, [user, userLoading, router]);
 
   // Update URL with current filter state
-  const updateURL = (
-    newSearchTerm?: string,
-    newDateRange?: { startDate: Date | null; endDate: Date | null },
-    newAuthor?: string | null
-  ) => {
-    const params = new URLSearchParams();
+  const updateURL = useCallback(
+    (
+      newSearchTerm?: string,
+      newDateRange?: { startDate: Date | null; endDate: Date | null },
+      newAuthor?: string | null
+    ) => {
+      const params = new URLSearchParams();
 
-    const currentSearchTerm = newSearchTerm !== undefined ? newSearchTerm : searchTerm;
-    const currentDateRange = newDateRange !== undefined ? newDateRange : dateRange;
-    const currentAuthor = newAuthor !== undefined ? newAuthor : selectedAuthor;
+      const currentSearchTerm = newSearchTerm !== undefined ? newSearchTerm : searchTerm;
+      const currentDateRange = newDateRange !== undefined ? newDateRange : dateRange;
+      const currentAuthor = newAuthor !== undefined ? newAuthor : selectedAuthor;
 
-    if (currentSearchTerm) {
-      params.set("search", currentSearchTerm);
-    }
+      if (currentSearchTerm) {
+        params.set("search", currentSearchTerm);
+      }
 
-    if (currentDateRange.startDate) {
-      params.set("startDate", currentDateRange.startDate.toISOString().split("T")[0]);
-    }
+      if (currentDateRange.startDate) {
+        params.set("startDate", currentDateRange.startDate.toISOString().split("T")[0]);
+      }
 
-    if (currentDateRange.endDate) {
-      params.set("endDate", currentDateRange.endDate.toISOString().split("T")[0]);
-    }
+      if (currentDateRange.endDate) {
+        params.set("endDate", currentDateRange.endDate.toISOString().split("T")[0]);
+      }
 
-    if (currentAuthor) {
-      params.set("author", currentAuthor);
-    }
+      if (currentAuthor) {
+        params.set("author", currentAuthor);
+      }
 
-    const queryString = params.toString();
-    const newURL = queryString ? `?${queryString}` : window.location.pathname;
-    router.replace(newURL, { scroll: false });
-  };
+      const queryString = params.toString();
+      const newURL = queryString ? `?${queryString}` : window.location.pathname;
+      router.replace(newURL, { scroll: false });
+    },
+    [searchTerm, dateRange, selectedAuthor, router]
+  );
 
   // Initialize filters from URL parameters
   const initializeFiltersFromURL = () => {
@@ -249,7 +252,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [searchTerm]);
+  }, [searchTerm, updateURL]);
 
   // Get unique authors for dropdown
   const uniqueAuthors = useMemo(() => getUniqueAuthors(notes), [notes]);
@@ -394,6 +397,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         const { note } = await response.json();
         setNotes((prev) => [...prev, note]);
         setAddingChecklistItem(note.id);
+        if (searchTerm || dateRange.startDate || dateRange.endDate || selectedAuthor) {
+          setSearchTerm("");
+          setDebouncedSearchTerm("");
+          setDateRange({ startDate: null, endDate: null });
+          setSelectedAuthor(null);
+          updateURL("", { startDate: null, endDate: null }, null);
+        }
       }
     } catch (error) {
       console.error("Error creating note:", error);


### PR DESCRIPTION
Problem: As you can see in the video, initially there are 2 notes. When I search something that isn't present in any note, and click on "Add Note", I cannot see new notes being created which leads to an inconsistent UX 

https://github.com/user-attachments/assets/4622af11-e048-47a0-a4f7-82c8a131d692

Solution: Clear the filters when "Add note" is clicked as it will lead to consistent UX

https://github.com/user-attachments/assets/4e0a5fb8-4eb9-45e7-ba2d-a7d74ecbd37b


