### PR TITLE
feat: board-activity

### DIFF
--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -184,6 +184,12 @@ export async function PUT(
       });
     });
 
+
+    await db.board.update({
+      where: { id: boardId },
+      data: { updatedAt: new Date() },
+    });
+
     if (archivedAt !== undefined && user.organization?.slackWebhookUrl && note.slackMessageId) {
       const userName = note.user?.name || note.user?.email || "Unknown User";
       const boardName = note.board.name;
@@ -309,6 +315,11 @@ export async function DELETE(
       data: {
         deletedAt: new Date(),
       },
+    });
+
+    await db.board.update({
+      where: { id: boardId },
+      data: { updatedAt: new Date() },
     });
 
     return NextResponse.json({ success: true });

--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -174,6 +174,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       },
     });
 
+
+    await db.board.update({
+      where: { id: boardId },
+      data: { updatedAt: new Date() },
+    });
+
     // Send Slack notification if note has checklist items with content
     const noteWithItems = note as typeof note & { checklistItems?: Array<{ content: string }> };
     const hasContent =

--- a/app/api/boards/all-notes/notes/route.ts
+++ b/app/api/boards/all-notes/notes/route.ts
@@ -145,6 +145,11 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    await db.board.update({
+      where: { id: boardId },
+      data: { updatedAt: new Date() },
+    });
+
     return NextResponse.json({ note }, { status: 201 });
   } catch (error) {
     console.error("Error creating note:", error);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/form";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
+import { formatActivityTime } from "@/lib/utils";
 
 // Dashboard-specific extended types
 export type DashboardBoard = Board & {
@@ -326,13 +327,24 @@ export default function Dashboard() {
                         </span>
                       </div>
                     </CardHeader>
-                    {board.description && (
                       <CardContent>
-                        <p className="text-slate-600 dark:text-zinc-300 truncate">
-                          {board.description}
+                          {board.description && (
+                            <p className="text-slate-600 dark:text-zinc-300 truncate">
+                              Description: {board.description}
+                            </p>
+                         )}
+                        <p className="text-slate-600 dark:text-zinc-500 truncate">
+                          {board._count.notes > 0 ? (
+                            <p className="text-slate-600 dark:text-zinc-500 truncate">
+                              Last Updated: {formatActivityTime(board.updatedAt)}
+                            </p>
+                          ) : (
+                            <p className="text-slate-600 dark:text-zinc-500 truncate">
+                              Created: {formatActivityTime(board.createdAt)}
+                            </p>
+                          )}
                         </p>
                       </CardContent>
-                    )}
                   </Card>
                 </Link>
               ))}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -252,3 +252,38 @@ export function filterAndSortNotes(
 
   return filteredNotes;
 }
+
+export function formatActivityTime(updatedAt: string) {
+  const now = new Date();
+  const updated = new Date(updatedAt);
+  const seconds = Math.floor((now - updated) / 1000);
+
+  // Minutes
+  let interval = Math.floor(seconds / 60);
+  if (interval < 60) {
+    return interval <= 1 ? '1m ago' : interval + 'm ago';
+  }
+
+  // Hours
+  interval = Math.floor(seconds / 3600);
+  if (interval < 24) {
+    return interval <= 1 ? '1hr ago' : interval + 'hrs ago';
+  }
+
+  // Days
+  interval = Math.floor(seconds / 86400);
+  if (interval < 30) {
+    return interval <= 1 ? '1 day ago' : interval + ' days ago';
+  }
+
+  // Months
+  interval = Math.floor(seconds / 2592000);
+  if (interval < 12) {
+    return interval <= 1 ? '1 month ago' : interval + ' months ago';
+  }
+
+  // Years
+  interval = Math.floor(seconds / 31536000);
+  return interval <= 1 ? '1 year ago' : interval + ' years ago';
+}
+

--- a/tests/e2e/board-activity.spec.ts
+++ b/tests/e2e/board-activity.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Board latest activity on dashboard", () => {
+  test("shows Created for new board then Last Updated after create/edit/delete note", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Activity Board"),
+        description: testContext.prefix("Board activity flow"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // 1) Dashboard initially shows Created
+    await authenticatedPage.goto("/dashboard");
+    const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+    await expect(boardCard).toBeVisible();
+    await expect(boardCard.getByText("Created:")).toBeVisible();
+
+    // 2) Open board and add two notes via UI (to keep count > 0 after deletion)
+    await boardCard.click();
+    await expect(authenticatedPage).toHaveURL(`/boards/${board.id}`);
+
+    const waitCreateNote1 = authenticatedPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/boards/${board.id}/notes`) &&
+        r.request().method() === "POST" &&
+        r.status() === 201
+    );
+    await authenticatedPage.getByRole("button", { name: "Add note" }).click();
+    await waitCreateNote1;
+
+    const waitCreateNote2 = authenticatedPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/boards/${board.id}/notes`) &&
+        r.request().method() === "POST" &&
+        r.status() === 201
+    );
+    await authenticatedPage.getByRole("button", { name: "Add note" }).click();
+    await waitCreateNote2;
+
+    // Work with the newest note (last card)
+    const lastNoteCard = authenticatedPage.locator('[data-testid="note-card"]').last();
+
+    // Add a checklist item to the newest note
+    const newItemTextarea = lastNoteCard.getByTestId("new-item").locator("textarea");
+    await expect(newItemTextarea).toBeVisible();
+    const initialItemText = testContext.prefix("Initial checklist item");
+    const addItemResp = authenticatedPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/boards/${board.id}/notes/`) &&
+        r.request().method() === "PUT" &&
+        r.ok()
+    );
+    await newItemTextarea.fill(initialItemText);
+    await newItemTextarea.blur();
+    await addItemResp;
+
+    // Back to dashboard → now should show Last Updated
+    await authenticatedPage.goto("/dashboard");
+    const boardCardAfterCreate = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+    await expect(boardCardAfterCreate.getByText("Last Updated:")).toBeVisible();
+
+    // Capture updatedAt after create
+    const afterCreate = await testPrisma.board.findUnique({ where: { id: board.id } });
+    expect(afterCreate).not.toBeNull();
+    const updatedAtAfterCreate = new Date(afterCreate!.updatedAt).getTime();
+
+    // Get the created item id to perform a precise edit
+    const createdItem = await testPrisma.checklistItem.findFirst({
+      where: { content: initialItemText },
+    });
+    expect(createdItem).not.toBeNull();
+    const itemId = createdItem!.id;
+
+    // 3) Edit the checklist item content → should bump updatedAt
+    await boardCardAfterCreate.click();
+    await expect(authenticatedPage).toHaveURL(`/boards/${board.id}`);
+
+    const saveEditResp = authenticatedPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/boards/${board.id}/notes/`) &&
+        r.request().method() === "PUT" &&
+        r.ok()
+    );
+    const editText = testContext.prefix("Edited checklist item");
+    const itemContainer = authenticatedPage.getByTestId(itemId);
+    await itemContainer.getByRole("textbox").fill(editText);
+    await authenticatedPage.locator("body").click();
+    await saveEditResp;
+
+    const afterEdit = await testPrisma.board.findUnique({ where: { id: board.id } });
+    expect(afterEdit).not.toBeNull();
+    expect(new Date(afterEdit!.updatedAt).getTime()).toBeGreaterThan(updatedAtAfterCreate);
+
+    await authenticatedPage.goto("/dashboard");
+    await expect(
+      authenticatedPage.locator(`[href="/boards/${board.id}"]`).getByText("Last Updated:")
+    ).toBeVisible();
+
+    // 4) Delete a note (ensure still ≥1 note remains) → should bump updatedAt
+    await authenticatedPage.locator(`[href="/boards/${board.id}"]`).click();
+    await expect(authenticatedPage).toHaveURL(`/boards/${board.id}`);
+
+    const waitDelete = authenticatedPage.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/boards/${board.id}/notes/`) &&
+        r.request().method() === "DELETE" &&
+        r.ok()
+    );
+    const deleteButtonInLastCard = lastNoteCard.getByRole("button", { name: /Delete Note/i });
+    await lastNoteCard.hover();
+    await deleteButtonInLastCard.click();
+    await waitDelete;
+
+    const afterDelete = await testPrisma.board.findUnique({ where: { id: board.id } });
+    expect(afterDelete).not.toBeNull();
+    expect(new Date(afterDelete!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(afterEdit!.updatedAt).getTime()
+    );
+
+    await authenticatedPage.goto("/dashboard");
+    await expect(
+      authenticatedPage.locator(`[href="/boards/${board.id}"]`).getByText("Last Updated:")
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Addresses #527

- Added **Activity** feature in board cards (Created, Last Updated)  
- Updates now trigger on all note mutations  
- Added end-to-end (e2e) tests 

### **Demo**
https://github.com/user-attachments/assets/39d3d3f6-ae4d-4d2b-bf6b-6ed0f7184e84

