### PR TITLE
feat: Added last activity time on boards 

### DIFF
--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -175,6 +175,7 @@ export async function PUT(
         data: {
           ...(color !== undefined && { color }),
           ...(archivedAt !== undefined && { archivedAt }),
+          ...(sanitizedChecklistItems !== undefined && { updatedAt: new Date() }),
         },
         include: {
           user: { select: { id: true, name: true, email: true, image: true } },

--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -175,7 +175,7 @@ export async function PUT(
         data: {
           ...(color !== undefined && { color }),
           ...(archivedAt !== undefined && { archivedAt }),
-          ...(sanitizedChecklistItems !== undefined && { updatedAt: new Date() }),
+          updatedAt: new Date(),
         },
         include: {
           user: { select: { id: true, name: true, email: true, image: true } },

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -42,11 +42,26 @@ export async function GET() {
             },
           },
         },
+        notes: {
+          select: { updatedAt: true },
+          where: {
+            deletedAt: null,
+            archivedAt: null,
+          },
+          orderBy: { updatedAt: "desc" },
+          take: 1,
+        },
       },
       orderBy: { createdAt: "desc" },
     });
 
-    return NextResponse.json({ boards });
+    const result = boards.map((board) => ({
+      ...board,
+      lastActivity: board.notes[0]?.updatedAt ?? board.updatedAt,
+      notes: undefined,
+    }));
+
+    return NextResponse.json({ boards: result });
   } catch (error) {
     console.error("Error fetching boards:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import z from "zod";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { Button } from "@/components/ui/button";
 import { BetaBadge } from "@/components/ui/beta-badge";
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/form";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
+import { formatLastUpdate } from "@/lib/utils";
 
 // Dashboard-specific extended types
 export type DashboardBoard = Board & {
@@ -48,6 +49,7 @@ export type DashboardBoard = Board & {
   createdAt: string;
   updatedAt: string;
   isPublic: boolean;
+  lastActivity: string;
   _count: { notes: number };
 };
 
@@ -333,6 +335,9 @@ export default function Dashboard() {
                         </p>
                       </CardContent>
                     )}
+                    <CardFooter>
+                      <p className=" text-sm">{formatLastUpdate(board.lastActivity)}</p>
+                    </CardFooter>
                   </Card>
                 </Link>
               ))}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -252,3 +252,19 @@ export function filterAndSortNotes(
 
   return filteredNotes;
 }
+
+export function formatLastUpdate(updatedAt: string): string {
+  const now = new Date();
+  const updated = new Date(updatedAt);
+  const diffMs = now.getTime() - updated.getTime();
+
+  const seconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (seconds < 60) return "Last activity: now";
+  if (minutes < 60) return `Last activity: ${minutes}m ago`;
+  if (hours < 24) return `Last activity: ${hours}h ago`;
+  return `Last activity: ${days}d ago`;
+}

--- a/tests/e2e/last-activity.spec.ts
+++ b/tests/e2e/last-activity.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test("should display last activity on dashboard board cards", async ({
+  authenticatedPage,
+  testContext,
+  testPrisma,
+}) => {
+  const board = await testPrisma.board.create({
+    data: {
+      name: testContext.getBoardName("Test Board"),
+      description: testContext.prefix("A test board"),
+      createdBy: testContext.userId,
+      organizationId: testContext.organizationId,
+    },
+  });
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      boardId: board.id,
+      createdBy: testContext.userId,
+    },
+  });
+
+  await authenticatedPage.goto("/dashboard");
+
+  const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+  await expect(boardCard).toBeVisible();
+  await expect(boardCard.locator("text=/Last activity:/")).toBeVisible();
+});
+
+test("should update last activity when note is modified", async ({
+  authenticatedPage,
+  testContext,
+  testPrisma,
+}) => {
+  const board = await testPrisma.board.create({
+    data: {
+      name: testContext.getBoardName("Test Board"),
+      description: testContext.prefix("A test board"),
+      createdBy: testContext.userId,
+      organizationId: testContext.organizationId,
+    },
+  });
+
+  const itemId = testContext.prefix("item-1");
+  const originalContent = testContext.prefix("Test item");
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      boardId: board.id,
+      createdBy: testContext.userId,
+      checklistItems: {
+        create: [
+          {
+            id: itemId,
+            content: originalContent,
+            checked: false,
+            order: 0,
+          },
+        ],
+      },
+    },
+  });
+
+  await authenticatedPage.goto(`/boards/${board.id}`);
+
+  await authenticatedPage.getByText(originalContent).click();
+  const editInput = authenticatedPage.getByTestId(itemId).getByRole("textbox");
+
+  const saveResponse = authenticatedPage.waitForResponse(
+    (resp) =>
+      resp.url().includes(`/api/boards/${board.id}/notes/`) && resp.request().method() === "PUT"
+  );
+
+  await editInput.fill(testContext.prefix("Updated item"));
+  await authenticatedPage.click("body");
+  await saveResponse;
+
+  await authenticatedPage.goto("/dashboard");
+  const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+  await expect(boardCard.locator("text=/Last activity: now/")).toBeVisible();
+});


### PR DESCRIPTION
closes #527


### Changes
- app/api/boards/[id]/notes/[noteId]/route.ts - Updates updatedAt when notes change
- app/api/boards/route.ts - Fetches last activity from notes for dashboard
- app/dashboard/page.tsx - Displays last activity on board cards
- lib/utils.ts - Added formatLastUpdate() function for time formatting
- tests/e2e/last-activity.spec.ts - Tests the complete feature flow

### Video

https://github.com/user-attachments/assets/47bc7f5c-58fd-4343-84bb-47c69897ab7e

### Test case 

<img width="523" height="180" alt="Screenshot 2025-08-19 at 11 08 19 PM" src="https://github.com/user-attachments/assets/ff8b558e-c46a-4668-bbae-a9c6bcb6823b" />
