### PR TITLE
fix: Authenticated users can still access the login page

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -159,13 +159,13 @@ function SignInContent() {
             </div>
             <Skeleton className="h-12 w-full" />
             <div className="relative mt-6 w-full">
-               <div className="absolute inset-0 flex items-center">
-                 <Skeleton className="h-px w-full" />
-               </div>
-               <div className="relative flex justify-center text-sm">
-                 <Skeleton className="h-4 w-24" />
-               </div>
-             </div>
+              <div className="absolute inset-0 flex items-center">
+                <Skeleton className="h-px w-full" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </div>
             <div className="space-y-3">
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />


### PR DESCRIPTION
## Description
Fixes authentication redirect issue where authenticated users could still access the login page

### Changes Made
- Added `useSession` hook to check authentication status in the sign-in page component
- Implemented redirect logic using useEffect to automatically redirect authenticated users to `/dashboard`
- Added skeleton loading state using the proper Skeleton component to prevent content flash during session checking
- Added conditional rendering with return null for authenticated users to prevent unwanted form display during redirect
        
Before

https://github.com/user-attachments/assets/6e7a8a70-2b1c-4db2-95a7-5d104fc04cd7



After

https://github.com/user-attachments/assets/20f2257b-b8fb-448a-903c-9892159ddda3



Fixes: https://github.com/antiwork/gumboard/issues/624