### PR TITLE
improve dark mode visibility for board not found message

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -675,7 +675,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Board not found</h1>
+          <h1 className="text-2xl font-bold mb-2 dark:text-white">Board not found</h1>
           <Button asChild>
             <Link href="/">Go to Gumboard</Link>
           </Button>

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -144,7 +144,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
     return (
       <div className="min-h-screen dark:bg-zinc-950 dark:text-zinc-100 flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Board not found</h1>
+          <h1 className="text-2xl font-bold mb-2 dark:text-white">Board not found</h1>
           <p className="text-muted-foreground mb-4">
             This board doesn&apos;t exist or is not publicly accessible.
           </p>


### PR DESCRIPTION
Before 

https://github.com/user-attachments/assets/6be1533e-105e-41ba-8432-7a0530e843b9

After

https://github.com/user-attachments/assets/bd20b70e-20a5-4c8b-a601-e7806ac47952

