### PR TITLE
feat: add copy note functionality to notes demo on homepage

### DIFF
--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -314,6 +314,20 @@ export function StickyNotesDemo() {
     setNotes(notes.filter((note) => note.id !== noteId));
   };
 
+  const handleCopyNote = (noteToCopy: Note) => {
+    const newNote: Note = {
+      ...noteToCopy,
+      id: `${Date.now()}`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      checklistItems: noteToCopy.checklistItems?.map((item, index) => ({
+        ...item,
+        id: `${Date.now()}-${index}`,
+      })) || [],
+    };
+    setNotes([newNote, ...notes]);
+  };
+
   const handleAddNote = () => {
     const randomColor = noteColors[Math.floor(Math.random() * noteColors.length)];
     const randomAuthor = authors[Math.floor(Math.random() * authors.length)];
@@ -366,6 +380,7 @@ export function StickyNotesDemo() {
                     currentUser={{ id: "demo-user", name: "Demo User", email: "demo@example.com" }}
                     onUpdate={handleUpdateNote}
                     onDelete={handleDeleteNote}
+                    onCopy={handleCopyNote}
                     syncDB={false}
                   />
                 </div>

--- a/components/sticky-notes-demo.tsx
+++ b/components/sticky-notes-demo.tsx
@@ -320,10 +320,11 @@ export function StickyNotesDemo() {
       id: `${Date.now()}`,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      checklistItems: noteToCopy.checklistItems?.map((item, index) => ({
-        ...item,
-        id: `${Date.now()}-${index}`,
-      })) || [],
+      checklistItems:
+        noteToCopy.checklistItems?.map((item, index) => ({
+          ...item,
+          id: `${Date.now()}-${index}`,
+        })) || [],
     };
     setNotes([newNote, ...notes]);
   };


### PR DESCRIPTION
### Summary

This PR implements the Copy Note functionality in the homepage notes demo.

### Before

The "Copy Note" action icon was visible, but clicking it did not perform any action.

### After

Clicking the "Copy Note" icon now successfully copies the note content.



https://github.com/user-attachments/assets/f902e2ed-d9e6-40fa-aee2-f4c39d61e4f2


