### PR TITLE
fix: hide copy button on archived notes

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -376,8 +376,8 @@ export function Note({
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          {canEdit && (
-            <div className="flex space-x-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+          <div className="flex space-x-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+            {canEdit && !note.archivedAt && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -397,6 +397,8 @@ export function Note({
                   <p>Copy note</p>
                 </TooltipContent>
               </Tooltip>
+            )}
+            {canEdit && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -416,8 +418,8 @@ export function Note({
                   <p>Delete note</p>
                 </TooltipContent>
               </Tooltip>
-            </div>
-          )}
+            )}
+          </div>
           {canEdit && onArchive && (
             <div className="flex items-center">
               <Tooltip>

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -1368,25 +1368,25 @@ test.describe("Note Management", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
     await expect(authenticatedPage.getByText("Active note content")).toBeVisible();
-    
+
     await expect(authenticatedPage.getByText("Archived note content")).not.toBeVisible();
-    
+
     const activeNote = authenticatedPage
       .locator('[data-testid="note-card"]')
       .filter({ hasText: "Active note content" })
       .first();
     await activeNote.hover();
-    await expect(activeNote.getByRole('button', { name: 'Copy note' })).toBeVisible();
-    
-    await authenticatedPage.goto('/boards/archive');
-    
+    await expect(activeNote.getByRole("button", { name: "Copy note" })).toBeVisible();
+
+    await authenticatedPage.goto("/boards/archive");
+
     const archivedNote = authenticatedPage
       .locator('[data-testid="note-card"]')
       .filter({ hasText: "Archived note content" })
       .first();
     await expect(archivedNote).toBeVisible();
-    
+
     await archivedNote.hover();
-    await expect(archivedNote.getByRole('button', { name: 'Copy note' })).not.toBeVisible();
+    await expect(archivedNote.getByRole("button", { name: "Copy note" })).not.toBeVisible();
   });
 });

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -1315,4 +1315,78 @@ test.describe("Note Management", () => {
     const deleteButton = noteCard.getByRole("button", { name: /Delete Note/i });
     await expect(deleteButton).not.toBeVisible();
   });
+
+  test("should hide copy button on archived notes", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const boardName = testContext.getBoardName("Note Actions Test Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Test board for note actions"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        boardId: board.id,
+        createdBy: testContext.userId,
+        archivedAt: new Date(),
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("Archived note content"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        boardId: board.id,
+        createdBy: testContext.userId,
+        checklistItems: {
+          create: [
+            {
+              content: testContext.prefix("Active note content"),
+              checked: false,
+              order: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+    await expect(authenticatedPage.getByText("Active note content")).toBeVisible();
+    
+    await expect(authenticatedPage.getByText("Archived note content")).not.toBeVisible();
+    
+    const activeNote = authenticatedPage
+      .locator('[data-testid="note-card"]')
+      .filter({ hasText: "Active note content" })
+      .first();
+    await activeNote.hover();
+    await expect(activeNote.getByRole('button', { name: 'Copy note' })).toBeVisible();
+    
+    await authenticatedPage.goto('/boards/archive');
+    
+    const archivedNote = authenticatedPage
+      .locator('[data-testid="note-card"]')
+      .filter({ hasText: "Archived note content" })
+      .first();
+    await expect(archivedNote).toBeVisible();
+    
+    await archivedNote.hover();
+    await expect(archivedNote.getByRole('button', { name: 'Copy note' })).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Changes
- Fixed an issue where the copy button was visible but non-functional on archived notes
- The copy action button is now properly hidden when a note is archived
- No changes to the copy functionality itself, just the visibility condition

Test result
<img width="370" height="207" alt="image" src="https://github.com/user-attachments/assets/cb7c5541-48f5-4102-a7a1-6e5ea801d057" />
