### PR TITLE
fix: align profile icon with add note button on mobile view

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -828,6 +828,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 }
               }}
               disabled={boardId === "archive"}
+              className="col-span-2 sm:col-span-1"
             >
               <span>Add note</span>
             </Button>


### PR DESCRIPTION
## Description
This PR fixes the mobile layout issue where the profile icon was appearing below the add note button on small screens.

The issue was caused by the accidental removal of the `col-span-2 sm:col-span-1` class on the "Add Note" button in [PR #540](https://github.com/antiwork/gumboard/pull/540)
. This PR restores that class.

### Before
<img width="356" height="205" alt="image" src="https://github.com/user-attachments/assets/fe633222-bab8-44e2-a13d-9c5bc6200f8d" />



### After
<img width="371" height="276" alt="image" src="https://github.com/user-attachments/assets/85b4910b-ae1a-458f-b5aa-ab41d67296e6" />

