### PR TITLE
fix(ui): improve delete board button spacing issue

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1121,7 +1121,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
               className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-              >
+            >
               <Trash2 className="w-4 h-4" />
               <span className="hidden lg:inline">
                 Delete Board

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1120,11 +1120,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
-              className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
+              className="hidden md:flex mr-auto items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
             >
               <Trash2 className="w-4 h-4" />
               <span>
-                Delete<span className="hidden lg:inline"> Board</span>
+                Delete<span className="hidden md:inline"> Board</span>
               </span>
             </Button>
             <div className="flex space-x-2 items-center">

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1120,11 +1120,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
-              className="hidden md:flex mr-auto items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-            >
+              className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
+              >
               <Trash2 className="w-4 h-4" />
-              <span>
-                Delete<span className="hidden md:inline"> Board</span>
+              <span className="hidden lg:inline">
+                Delete Board
               </span>
             </Button>
             <div className="flex space-x-2 items-center">

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1120,10 +1120,12 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
-              className="mr-auto bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
+              className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
             >
               <Trash2 className="w-4 h-4" />
-              Delete <span className="hidden lg:inline">Board</span>
+              <span>
+                Delete<span className="hidden lg:inline"> Board</span>
+              </span>
             </Button>
             <div className="flex space-x-2 items-center">
               <AlertDialogCancel className="border-gray-400 text-foreground dark:text-zinc-100 dark:border-zinc-700 hover:bg-zinc-100 hover:text-foreground hover:border-gray-200 dark:hover:bg-zinc-800">


### PR DESCRIPTION
### Changes
- Improved spacing/alignment for:
  - Delete Board button
### Why
- Buttons previously had inconsistent gaps between icons and text.
  
Before
<img width="587" height="147" alt="delete-before" src="https://github.com/user-attachments/assets/3e1f605f-7acf-4852-b94d-a71ac2881393" />

After

<img width="675" height="200" alt="after-delete" src="https://github.com/user-attachments/assets/3cbcdd0a-7dcc-44d8-ae13-75cb1beda3b0" />

After view deleting the "delete board" button
<img width="585" height="192" alt="small-delte" src="https://github.com/user-attachments/assets/e5b14ba2-dd41-474f-8435-12c1164d7844" />


