### PR TITLE
fix(ui): improve "Send Invite" button spacing issue

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -648,13 +648,7 @@ export default function OrganizationSettingsPage() {
               title={!user?.isAdmin ? "Only admins can invite new team members" : undefined}
             >
               <UserPlus className="w-4 h-4" />
-              {inviting ? (
-                "Inviting..."
-              ) : (
-                <span>
-                  <span className="hidden lg:inline">Send </span>Invite
-                </span>
-              )}
+              {inviting ? "Inviting..." : <span className="hidden lg:inline">Send Invite</span>}
             </Button>
           </form>
 


### PR DESCRIPTION
Ref #411 
### Changes
- Improved spacing/alignment for:
  - Send Invite button


### Why
- Buttons previously had inconsistent gaps between icons and text.

Before

<img width="800" height="151" alt="invite-before" src="https://github.com/user-attachments/assets/ba4cc258-e572-46ef-bc58-a8ec0dd4e544" />



After

<img width="850" height="187" alt="invite-after" src="https://github.com/user-attachments/assets/729517c2-d5e9-4c19-a69d-72c90191058a" />


After in moblie view
<img width="767" height="151" alt="invite-small" src="https://github.com/user-attachments/assets/3e6b7914-2669-411a-aaf8-bcac2ded02b8" />
