### PR TITLE
fix(ui): improve "Create Invite Link" button spacing  issue

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -766,11 +766,7 @@ export default function OrganizationSettingsPage() {
               title={!user?.isAdmin ? "Only admins can create invite links" : undefined}
             >
               <Link className="w-4 h-4" />
-              {creating ? (
-                "Creating..."
-              ) : (
-                <span className="hidden md:inline">Create Invite Link</span>
-              )}
+              {creating ? "Creating..." : "Create Invite Link"}
             </Button>
           </form>
 

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -762,11 +762,15 @@ export default function OrganizationSettingsPage() {
             <Button
               type="submit"
               disabled={creating || !user?.isAdmin}
-              className="disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white dark:text-zinc-100"
+              className="disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white dark:text-zinc-100 flex items-center gap-2"
               title={!user?.isAdmin ? "Only admins can create invite links" : undefined}
             >
-              <Link className="w-4 h-4 mr-2" />
-              {creating ? "Creating..." : "Create Invite Link"}
+              <Link className="w-4 h-4" />
+              {creating ? (
+                "Creating..."
+              ) : (
+                <span className="hidden md:inline">Create Invite Link</span>
+              )}
             </Button>
           </form>
 


### PR DESCRIPTION
### Changes
- Improved spacing/alignment for:
  - Create Invite Link button


### Why
- Buttons previously had inconsistent gaps between icons and text.

Before

<img width="826" height="245" alt="before-creare-invite" src="https://github.com/user-attachments/assets/6b035acb-8017-4b2f-8d8b-39551b9c700e" />

After
<img width="810" height="259" alt="Screenshot_2025-08-21_12-58-04" src="https://github.com/user-attachments/assets/5d28727d-670e-415d-8708-48237d4dd457" />


After view for the moblie 
<img width="447" height="471" alt="sssssssss" src="https://github.com/user-attachments/assets/e1a8b9d1-d8ad-4deb-a40c-efddd31d0577" />

