### PR TITLE
fix: style of "Try again" button Authentication Error page in dark mode

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -41,7 +41,7 @@ function AuthErrorContent() {
         <div className="pt-4">
           <Button
             asChild
-            className="w-full dark:bg-zinc-900 dark:text-zinc-100 dark:border-zinc-700"
+            className="w-full"
           >
             <Link href="/auth/signin">
               <ArrowLeft className="w-4 h-4 mr-2" />

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -39,10 +39,7 @@ function AuthErrorContent() {
           <p className="text-sm text-muted-foreground dark:text-zinc-400">{errorMessage}</p>
         </div>
         <div className="pt-4">
-          <Button
-            asChild
-            className="w-full"
-          >
+          <Button asChild className="w-full">
             <Link href="/auth/signin">
               <ArrowLeft className="w-4 h-4 mr-2" />
               Try again


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/c17186d7-077a-49c3-a40c-e73f3169f6ce

After:

https://github.com/user-attachments/assets/e55594c7-e2a8-44b9-8b79-5687fb24b7ac


## Changes Made
- Removed dark mode specific styling (`dark:bg-zinc-900 dark:text-zinc-100 dark:border-zinc-700`) from the "Try again" button
- Simplified button styling to use consistent appearance across both light and dark themes

## AI Usage
-No AI tools used for this PR and code changes

## Self-Review Checklist
- [x] No bugs or issues remain  
- [x] Code follows project style guidelines  
- [x] All tests pass locally  
- [x] Changes are only on the visibility issue  

