### PR TITLE
fix: last-active-bug

### DIFF
--- a/app/api/boards/[id]/notes/[noteId]/route.ts
+++ b/app/api/boards/[id]/notes/[noteId]/route.ts
@@ -309,11 +309,6 @@ export async function DELETE(
       where: { id: noteId },
       data: {
         deletedAt: new Date(),
-        board: {
-          update: {
-            updatedAt: new Date(),
-          },
-        },
       },
     });
 

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -43,10 +43,6 @@ export async function GET() {
           },
         },
         notes: {
-          where: {
-            deletedAt: null,
-            archivedAt: null,
-          },
           select: {
             updatedAt: true,
           },
@@ -60,14 +56,7 @@ export async function GET() {
     });
 
     const boardsWithLastActivityTimestamp = boards.map((board) => ({
-      id: board.id,
-      name: board.name,
-      description: board.description,
-      isPublic: board.isPublic,
-      createdBy: board.createdBy,
-      createdAt: board.createdAt,
-      updatedAt: board.updatedAt,
-      _count: board._count,
+      ...board,
       lastActivityAt: board.notes[0]?.updatedAt ?? board.updatedAt,
     }));
 


### PR DESCRIPTION
Bug: When a note is deleted from a board, the Last Active timestamp does not update as expected.

### Changes
- Removed the WHERE filter to fetch the latest board activity.
- Removed unnecessary updatedAt update from the delete route when deleting a note from the board.
- Removed unnecessary extra code while mapping

### before
https://github.com/user-attachments/assets/c16b61dd-2f0d-4f6a-a73c-42577255c7a0



### after
https://github.com/user-attachments/assets/b7517597-bbaa-40a5-8936-3f3c2c4a15c5

