### PR TITLE
Issue 671 links clickable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
### What
This PR makes links inside checklist items clickable when the item is not being edited. Previously, links were plain text and needed to be copied manually.

### Changes
- Detect URLs in checklist item text and convert them to clickable <a> links.
- Links open in a new tab.
- Line breaks are preserved.
- While editing, text remains in a <textarea> for normal editing.
- Changes are isolated to `components/checklist-item.tsx` and have no API impact.

**Before:** 

https://github.com/user-attachments/assets/088ba4f7-52ca-4ae2-abd0-9af5d98c6792


**After:** 

https://github.com/user-attachments/assets/db85eb9b-9156-4065-8ffb-208f414f5bc0



### Issue Reference
 #671 
