### PR TITLE
fix: handle long email addresses in pending invites

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -662,7 +662,9 @@ export default function OrganizationSettingsPage() {
                   className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-900 rounded-lg border border-yellow-200 dark:border-yellow-800"
                 >
                   <div className="min-w-0">
-                    <p className="font-medium text-zinc-900 dark:text-zinc-100 break-words">{invite.email}</p>
+                    <p className="font-medium text-zinc-900 dark:text-zinc-100 break-words">
+                      {invite.email}
+                    </p>
                     <p className="text-sm text-zinc-600 dark:text-zinc-400">
                       Invited on {new Date(invite.createdAt).toLocaleDateString()}
                     </p>


### PR DESCRIPTION
This PR fixes a UI issue where long email addresses overflowed in the "Pending Invites" section on mobile.

Before
<img width="325" alt="image" src="https://github.com/user-attachments/assets/5812ecf2-6c7f-41c9-821b-8c5fb0ca36d6" />


After

<img width="325" height="254" alt="Screenshot 2025-08-22 at 20 22 38" src="https://github.com/user-attachments/assets/5c7e8768-8439-44aa-a746-6e5a17234cac" />
