### PR TITLE
fix: improve tablet responsiveness for card grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -91,7 +91,7 @@ export default async function HomePage() {
               </p>
             </div>
 
-            <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto">
+            <div className="grid gap-8 md:grid-cols-3 max-w-6xl mx-auto">
               {features.map((feature) => {
                 const IconComponent = feature.icon;
                 return (


### PR DESCRIPTION
Description:

On tablet view, the layout used sm:grid-cols-2 which caused the third card to drop under the first column, creating an awkward visual gap.
This PR enforces md:grid-cols-3 so that three cards align properly at tablet sizes, improving overall UI consistency without making cards too small.

Before:

<img width="1107" height="858" alt="Screenshot 2025-08-26 181022" src="https://github.com/user-attachments/assets/0b0ac41e-6b20-4ecf-bbfd-27e08034215c" />

After:

<img width="1100" height="859" alt="Screenshot 2025-08-26 181057" src="https://github.com/user-attachments/assets/74f78f06-e8ea-49a9-81a9-3340fc879c93" />


No AI was used to generate any of this code.
