### PR TITLE
feat: add placeholder text for new note checklist items

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -125,6 +125,7 @@ export function ChecklistItem({
         value={editContent ?? item.content}
         onChange={(e) => onEditContentChange?.(e.target.value)}
         disabled={readonly}
+        placeholder={isNewItem ? "Start typing…" : undefined}
         className={cn(
           "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
           item.checked && "text-zinc-500 dark:text-zinc-500 line-through"


### PR DESCRIPTION

- Add 'Start typing…' placeholder to new checklist items
- Only shows when isNewItem is true


<img width="682" height="567" alt="Screenshot 2025-08-28 at 10 02 45 AM" src="https://github.com/user-attachments/assets/63ce35c6-945c-45e5-9a2d-9d701600fe3c" />

- Resolves #680
Kindly Review!