### PR TITLE
Fix: allow Board settings dialog to close when clicking outside

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1008,7 +1008,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       </AlertDialog>
 
       <AlertDialog open={boardSettingsDialog} onOpenChange={setBoardSettingsDialog}>
-        <AlertDialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 p-4 lg:p-6">
+        <AlertDialogContent className="board-settings-modal bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 p-4 lg:p-6">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-foreground dark:text-zinc-100">
               Board settings

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -174,15 +174,17 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   // Close dropdowns when clicking outside and handle escape key
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (showBoardDropdown || showAddBoard) {
+      if (showBoardDropdown || showAddBoard || boardSettingsDialog) {
         const target = event.target as Element;
         if (
           !target.closest(".board-dropdown") &&
           !target.closest(".user-dropdown") &&
-          !target.closest(".add-board-modal")
+          !target.closest(".add-board-modal") &&
+          !target.closest(".board-settings-modal")
         ) {
           setShowBoardDropdown(false);
           setShowAddBoard(false);
+          setBoardSettingsDialog(false);
         }
       }
     };
@@ -200,6 +202,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           setNewBoardName("");
           setNewBoardDescription("");
         }
+        if (boardSettingsDialog) {
+          setBoardSettingsDialog(false);
+        }
       }
     };
 
@@ -209,7 +214,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [showBoardDropdown, showAddBoard, addingChecklistItem]);
+  }, [showBoardDropdown, showAddBoard, boardSettingsDialog, addingChecklistItem]);
 
   useEffect(() => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
Improved UX for Board settings dialog.  
Currently, the dialog can only be closed via the "Cancel" button.  
This change allows the dialog to also close when clicking anywhere outside of it.  

## Changes
- Added outside click handler for Board settings dialog.
- Preserves existing cancel button functionality.

## Before:

https://github.com/user-attachments/assets/008b2046-746c-47c0-af81-74cb51d53446

## After:


https://github.com/user-attachments/assets/ba132843-6218-468f-8e41-8217da4babbd


## Testing
- Verified that dialog opens as before.
- Cancel button still closes the dialog.
- Clicking outside now properly closes the dialog.

## No AI was used to generate any of this code.

