### PR TITLE
fix: style of 'Clear all filters' button  on boards page

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -876,8 +876,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   setSelectedAuthor(null);
                   updateURL("", { startDate: null, endDate: null }, null);
                 }}
-                variant="outline"
-                className="flex items-center space-x-2 cursor-pointer"
+                variant="default"
               >
                 <span>Clear All Filters</span>
               </Button>


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/df72e50f-1633-4dd6-a3f2-d6f2ab763d61

After:

https://github.com/user-attachments/assets/944034f7-ceab-4082-b33c-33dd4582963e

## Changes Made
- Updated `variant="outline"` to `variant="default"` for the "Clear all filters" button on Boards page  
- Ensured the button is more clearly visible to the user

## AI Usage
- No AI tools used for this PR and code changes

## Self-Review Checklist
- [x] No bugs or issues remain
- [x] Code follows project style guidelines
- [x] All tests pass locally
- [x] Changes are only on the visibility issue

