### PR TITLE
fix: Truncate changes

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -641,7 +641,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 className="board-dropdown mr-0 min-w-32 sm:max-w-64 col-span-2 sm:col-span-1"
               >
                 <Button variant="ghost" className="flex items-center justify-between p-2 w-full">
-                  <div className="text-sm font-semibold text-foreground dark:text-zinc-100">
+                  <div className="text-sm font-semibold truncate text-foreground dark:text-zinc-100">
                     {boardId === "all-notes"
                       ? "All notes"
                       : boardId === "archive"

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -641,7 +641,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 className="board-dropdown mr-0 min-w-32 sm:max-w-64 col-span-2 sm:col-span-1"
               >
                 <Button variant="ghost" className="flex items-center justify-between p-2 w-full">
-                  <div className="text-sm font-semibold truncate text-foreground dark:text-zinc-100">
+                  <div className="text-sm font-semibold text-foreground dark:text-zinc-100 truncate">
                     {boardId === "all-notes"
                       ? "All notes"
                       : boardId === "archive"

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -366,7 +366,7 @@ export function Note({
             />
           </Avatar>
           <div className="flex flex-col">
-            <span className="text-sm font-bold text-gray-700 dark:text-zinc-100 truncate max-w-20">
+            <span className="text-sm font-bold text-gray-700 dark:text-zinc-100 max-w-20">
               {note.user.name ? note.user.name.split(" ")[0] : note.user.email.split("@")[0]}
             </span>
             <div className="flex flex-col">


### PR DESCRIPTION
there were two small truncate issue. so have pushed it in the same pull request.

## overflow when a long board title
before:
<img width="623" height="175" alt="Screenshot 2025-08-30 at 9 53 17 AM" src="https://github.com/user-attachments/assets/c811c593-eb10-40ee-84f8-0abdafcf918d" />

after:
<img width="1512" height="982" alt="Screenshot 2025-08-30 at 9 53 07 AM" src="https://github.com/user-attachments/assets/11dbbb5d-2aa2-423e-86b8-c03f0fb7a4a5" />

## unwanted truncate on name
after:
<img width="1512" height="324" alt="Screenshot 2025-08-30 at 10 24 37 AM" src="https://github.com/user-attachments/assets/9a58134b-b183-4f0c-8591-aa3a12a54e20" />
before:
<img width="1512" height="430" alt="Screenshot 2025-08-30 at 10 24 55 AM" src="https://github.com/user-attachments/assets/b1fd0834-2a41-485a-bec1-3aceccd9f85a" />

### used of AI
None