### PR TITLE
test: Add invite acceptance e2e tests

### DIFF
--- a/tests/e2e/invite-accept.spec.ts
+++ b/tests/e2e/invite-accept.spec.ts
@@ -36,26 +36,27 @@ const test = base.extend<{ inviteToken: string }>({
 });
 
 test.describe("Invite Acceptance", () => {
-  test("accepting a valid invite redirects to dashboard", async ({ authenticatedPage, inviteToken }) => {
+  test("accepting a valid invite redirects to dashboard", async ({
+    authenticatedPage,
+    inviteToken,
+  }) => {
     await authenticatedPage.goto(`/invite/accept?token=${inviteToken}`);
     const acceptButton = authenticatedPage.locator('button:has-text("Accept Invitation")');
 
-    await Promise.all([
-      authenticatedPage.waitForURL(/.*dashboard/),
-      acceptButton.click(),
-    ]);
+    await Promise.all([authenticatedPage.waitForURL(/.*dashboard/), acceptButton.click()]);
 
     await expect(authenticatedPage).toHaveURL(/.*dashboard/);
   });
 
-  test("declining marks invite declined", async ({ authenticatedPage, inviteToken, testPrisma }) => {
+  test("declining marks invite declined", async ({
+    authenticatedPage,
+    inviteToken,
+    testPrisma,
+  }) => {
     await authenticatedPage.goto(`/invite/accept?token=${inviteToken}`);
     const declineButton = authenticatedPage.locator('button:has-text("Decline Invitation")');
 
-    await Promise.all([
-      authenticatedPage.waitForURL(/.*dashboard/),
-      declineButton.click(),
-    ]);
+    await Promise.all([authenticatedPage.waitForURL(/.*dashboard/), declineButton.click()]);
 
     const invite = await testPrisma.organizationInvite.findUnique({ where: { id: inviteToken } });
     expect(invite?.status).toBe("DECLINED");

--- a/tests/e2e/invite-accept.spec.ts
+++ b/tests/e2e/invite-accept.spec.ts
@@ -1,0 +1,69 @@
+import { test as base, expect } from "../fixtures/test-helpers";
+
+// Extend base test with inviteToken fixture that seeds an invite before each scenario
+const test = base.extend<{ inviteToken: string }>({
+  inviteToken: async ({ testContext, testPrisma }, use) => {
+    // Create a separate organization and user to send the invite
+    const inviterOrgId = testContext.prefix("invite-org");
+    const inviterUserId = testContext.prefix("invite-user");
+
+    await testPrisma.organization.create({
+      data: {
+        id: inviterOrgId,
+        name: `Invite Org ${testContext.testId}`,
+      },
+    });
+
+    await testPrisma.user.create({
+      data: {
+        id: inviterUserId,
+        email: `inviter-${testContext.testId}@example.com`,
+        name: "Inviter User",
+        organizationId: inviterOrgId,
+      },
+    });
+
+    const invite = await testPrisma.organizationInvite.create({
+      data: {
+        email: testContext.userEmail,
+        organizationId: inviterOrgId,
+        invitedBy: inviterUserId,
+      },
+    });
+
+    await use(invite.id);
+  },
+});
+
+test.describe("Invite Acceptance", () => {
+  test("accepting a valid invite redirects to dashboard", async ({ authenticatedPage, inviteToken }) => {
+    await authenticatedPage.goto(`/invite/accept?token=${inviteToken}`);
+    const acceptButton = authenticatedPage.locator('button:has-text("Accept Invitation")');
+
+    await Promise.all([
+      authenticatedPage.waitForURL(/.*dashboard/),
+      acceptButton.click(),
+    ]);
+
+    await expect(authenticatedPage).toHaveURL(/.*dashboard/);
+  });
+
+  test("declining marks invite declined", async ({ authenticatedPage, inviteToken, testPrisma }) => {
+    await authenticatedPage.goto(`/invite/accept?token=${inviteToken}`);
+    const declineButton = authenticatedPage.locator('button:has-text("Decline Invitation")');
+
+    await Promise.all([
+      authenticatedPage.waitForURL(/.*dashboard/),
+      declineButton.click(),
+    ]);
+
+    const invite = await testPrisma.organizationInvite.findUnique({ where: { id: inviteToken } });
+    expect(invite?.status).toBe("DECLINED");
+  });
+
+  test("invalid or expired tokens show error card", async ({ authenticatedPage, inviteToken }) => {
+    // inviteToken fixture seeds the database even though we use an invalid token in the URL
+    await authenticatedPage.goto(`/invite/accept?token=invalid-token`);
+    await expect(authenticatedPage.locator("text=Invalid Invitation")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What Changed
- Added a new **Playwright e2e test suite** for invite acceptance:
  - Seeds an **organization invite** before each scenario via a custom `inviteToken` fixture.  
  - Ensures every test runs with **fresh invite data**.  
  - Covers **valid acceptance**, **decline flow**, and **invalid/expired token** handling.

## Why
- Invite acceptance flow is **critical for onboarding collaborators**.  
- Previously untested — risk of regressions in **dashboard redirects, decline status updates, and error handling**.  
- These tests ensure consistent and correct behavior across all invite scenarios.

## Testing
- Ran the new test suite locally with `npm run test:e2e invite-accept.spec.ts`.  
- All three scenarios passed successfully:  
  -  Accepting a valid invite redirects to **Dashboard**.  
  -  Declining an invite updates status to **DECLINED** in DB.  
  -  Invalid/expired tokens display **“Invalid Invitation”** card.  
- Verified results in **Playwright HTML report**.  
- Attached screenshot evidence of successful runs.

## Screenshots (test run)
<img width="1008" height="353" alt="invite-test" src="https://github.com/user-attachments/assets/ca1452c7-d4b2-40e1-b4a3-6718950d5527" />


## Checklist
- [x] All new tests pass locally.  
- [x] Verified behavior in **accept**, **decline**, and **invalid invite** cases.  
- [x] Self-reviewed for clarity and coverage.  
- [x] Added screenshots from Playwright run for evidence.  

## AI Assistance
No AI was used to generate any of this code or description.  
