### PR TITLE
feat: use calendar date picker for invite expiry

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -773,10 +773,11 @@ export default function OrganizationSettingsPage() {
                       autoFocus
                       showOutsideDays={true}
                       classNames={{
+                        day: "cursor-pointer relative z-20 !pointer-events-auto",
+                        outside:
+                          "text-zinc-400 dark:text-zinc-700 opacity-60 hover:bg-accent hover:text-accent-foreground cursor-pointer !pointer-events-auto relative z-20",
                         weekday:
                           "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",
-                        outside:
-                          "text-zinc-400 dark:text-zinc-700 opacity-60 hover:bg-accent hover:text-accent-foreground cursor-pointer",
                         caption_label: "text-zinc-900 dark:text-zinc-100",
                       }}
                     />


### PR DESCRIPTION
## Description
- Replaced the native HTML <input type="date" /> with a consistent Popover + Calendar date picker.
- Keeps the same functionality:
    -  Stores date as yyyy-MM-dd in state (unchanged).
    - Displayed to users as dd-MM-yyyy.
    - Non-admin users still cannot change the expiry date.
    
- Improves UX with better dark mode support and unified styling.

## Notes
- No backend or API changes.
- Behavior is identical to the previous implementation, only the UI is upgraded.

## Before

https://github.com/user-attachments/assets/71e71c51-b997-49c1-8148-bfe3fe850de6




## After

https://github.com/user-attachments/assets/a266603f-1f0a-4a9f-b0bc-24fa69a09086





## AI Disclosure
- AI assistance (ChatGPT) was only used to **review and verify** the correctness and safety of the implementation.  
The code itself was originally written by me.