### PR TITLE
fix: correctly update status of expired invite links

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -788,9 +788,15 @@ export default function OrganizationSettingsPage() {
                           <h5 className="font-medium text-zinc-900 dark:text-zinc-100">
                             {invite.name}
                           </h5>
-                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                            Active
-                          </span>
+                          {(invite.expiresAt ? new Date(invite.expiresAt) < new Date() : false) ? (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                              Expired
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                              Active
+                            </span>
+                          )}
                         </div>
                         <div className="flex items-center space-x-2 ml-4">
                           <Button


### PR DESCRIPTION
### Explanation of Change
Fixes a bug where expired invite links are still displayed as "Active"

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="845" height="261" alt="image" src="https://github.com/user-attachments/assets/ddb493ae-20a5-4ce5-a26e-16884a62c392" />

</details>

<details>
<summary>After</summary>

<img width="852" height="274" alt="image" src="https://github.com/user-attachments/assets/a1ae4f43-6c80-4eb4-9e18-163b7916d964" />

<img width="849" height="261" alt="image" src="https://github.com/user-attachments/assets/40f7fd3b-da3e-44c0-a5de-8d440ce42046" />

</details>

### AI Disclosure
No AI tools used