### PR TITLE
fix: make use of apply button in date picker

### DIFF
--- a/components/ui/date-range-picker.tsx
+++ b/components/ui/date-range-picker.tsx
@@ -47,9 +47,6 @@ function DateRangePicker({
       setInternalStartDate(date);
       if (internalEndDate && isAfter(date, internalEndDate)) {
         setInternalEndDate(null);
-        onDateRangeChange?.(date, null);
-      } else {
-        onDateRangeChange?.(date, internalEndDate);
       }
     }
     setIsStartPopoverOpen(false);
@@ -58,7 +55,6 @@ function DateRangePicker({
   const handleEndCalendarSelect = (date: Date | undefined) => {
     if (date && internalStartDate && isAfter(internalStartDate, date)) return;
     setInternalEndDate(date || null);
-    onDateRangeChange?.(internalStartDate, date || null);
     setIsEndPopoverOpen(false);
   };
 
@@ -69,7 +65,10 @@ function DateRangePicker({
     setIsFilterDropdownOpen(false);
   };
 
-  const handleApply = () => setIsFilterDropdownOpen(false);
+  const handleApply = () => {
+    onDateRangeChange?.(internalStartDate, internalEndDate);
+    setIsFilterDropdownOpen(false);
+  };
 
   useEffect(() => {
     setInternalStartDate(startDate || null);


### PR DESCRIPTION
#411
currently when we pick the date start and end. it trigger the api and apply the changes.
but these changes should be only apply when we click on the apply button and not when we pick the date. 
same behavior as the board setting where we only apply the public toggle when we save it.

before:

https://github.com/user-attachments/assets/ee16dc72-ce4b-48f2-988f-49f6aeba43cf


after:

https://github.com/user-attachments/assets/f93534e9-2f85-4ffe-95f9-b918d5149f82


## use of AI 
no use of AI in this pr.