### PR TITLE
fix: Center align email icon in profile settings.

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -120,15 +120,15 @@ export default function ProfileSettingsPage() {
             <Label htmlFor="email" className="text-foreground dark:text-zinc-200">
               Email Address
             </Label>
-            <div className="relative mt-1">
+            <div className="relative mt-2">
               <Input
                 id="email"
                 type="email"
                 value={user?.email || ""}
                 disabled
-                className="mt-1 bg-muted dark:bg-zinc-800 text-muted-foreground dark:text-zinc-400 cursor-not-allowed"
+                className="bg-muted dark:bg-zinc-800 text-muted-foreground dark:text-zinc-400 cursor-not-allowed pr-10"
               />
-              <Mail className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground dark:text-zinc-400" />
+              <Mail className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground dark:text-zinc-400 pointer-events-none" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Fix email icon alignment in profile settings

### Fixes
#411 

### Problem
The email icon in the profile settings page was not properly center-aligned within the input field, creating a visual inconsistency in the form layout.

### Solution
- Removed duplicate `mt-1` margin from the email input field
- Updated container margin to `mt-2` for consistent spacing with other form elements
- Added `pr-10` padding to prevent text overlap with the icon
- Simplified icon positioning with `-translate-y-1/2` and added `pointer-events-none`

### Changes
- `app/settings/page.tsx`: Updated email input field styling and icon positioning

### Screenshots

#### Before
<img width="808" height="545" alt="Screenshot 2025-09-10 at 12 28 02 AM" src="https://github.com/user-attachments/assets/54bb28b5-68e8-447d-bf3e-567255c0a792" />

#### After
<img width="802" height="538" alt="Screenshot 2025-09-10 at 12 28 28 AM" src="https://github.com/user-attachments/assets/ac92cbac-12e5-40a7-bb41-0a0d71b70054" />

### AI disclosure 
No AI used