### PR TITLE
fix: Center align checkbox in board settings dialog

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1120,7 +1120,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 onCheckedChange={(checked) =>
                   setBoardSettings((prev) => ({ ...prev, sendSlackUpdates: checked as boolean }))
                 }
-                className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-600 mt-1"
+                className="border-slate-500 bg-white/50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-600"
               />
               <label
                 htmlFor="sendSlackUpdates"


### PR DESCRIPTION
## Fix checkbox alignment in board settings dialog

### Fixes #411 

### Problem
The "Send updates to Slack" checkbox in the board settings dialog was not properly center-aligned with its label text, creating a visual inconsistency in the form layout.

### Solution
- Removed the `mt-1` margin class from the Checkbox component that was causing misalignment
- The parent container already uses `flex items-center` which properly handles vertical centering
- The extra margin was pushing the checkbox down and disrupting the natural flex alignment

### Changes
- `app/boards/[id]/page.tsx`: Removed `mt-1` class from the Slack updates checkbox

### Screenshots

#### Before
<img width="517" height="487" alt="Screenshot 2025-09-10 at 12 44 41 AM" src="https://github.com/user-attachments/assets/b51ac2e8-55e7-47d5-bebb-7825e6dccf68" />

#### After
<img width="517" height="484" alt="Screenshot 2025-09-10 at 12 45 19 AM" src="https://github.com/user-attachments/assets/7735b9d1-ee73-43e9-8135-515bd21d66ce" />

#### AI disclosure 

No AI used.
