### PR TITLE
fix: delete account dialog text alignment in mobile view

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -176,7 +176,7 @@ export default function ProfileSettingsPage() {
                         </AlertDialogTitle>
                         <AlertDialogDescription
                           asChild
-                          className="text-foreground dark:text-zinc-100"
+                          className="text-foreground dark:text-zinc-100 text-left"
                         >
                           <div>
                             This will permanently delete your account and related data. This action


### PR DESCRIPTION
### Description:

For delete account dialog in mobile view, text align to center for list items leading to poor ux.

Part of #411  

### Before / After:

#### Before:

 <table>
 <tr><th>Dark theme</th><th>Light theme</th></tr>
 <tr>
 <td> 
<img width="522" height="810" alt="Screenshot 2025-09-10 at 12 22 52 AM" src="https://github.com/user-attachments/assets/f98814b5-5313-47f7-b363-db0e1aeacc8f" />
 </td>
 <td>
<img width="524" height="807" alt="Screenshot 2025-09-10 at 12 23 27 AM" src="https://github.com/user-attachments/assets/cf731612-9b16-4a6e-a7e9-fb00e9e1a27b" />
 </td>
 </tr>
 </table>

#### After:

 <table>
 <tr><th>Dark theme</th><th>Light theme</th></tr>
 <tr>
 <td> 
<img width="497" height="806" alt="Screenshot 2025-09-10 at 12 32 10 AM" src="https://github.com/user-attachments/assets/125b1a5d-52e2-415a-bc22-ecd7c6e303cc" />
 </td>
 <td>
<img width="494" height="813" alt="Screenshot 2025-09-10 at 12 31 55 AM" src="https://github.com/user-attachments/assets/25f5c400-722f-49fc-814d-270f83621270" />
 </td>
 </tr>
 </table>


### Test Suite / Related tests:

CSS change, no impact on tests.

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.
>Self-review: All changes are intuitive, so no additional comments are needed.