### PR TITLE
Consistent background color on autofil

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,18 @@ html.dark {
 .dark input[type="date"]::-webkit-calendar-picker-indicator {
   filter: invert(1);
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-text-fill-color: #000 !important;
+  transition: background-color 5000s ease-in-out 0s !important;
+}
+
+.dark input:-webkit-autofill,
+.dark input:-webkit-autofill:hover,
+.dark input:-webkit-autofill:focus,
+.dark input:-webkit-autofill:active {
+  -webkit-text-fill-color: #fff !important;
+}


### PR DESCRIPTION
Added CSS rules to neutralize browser autofill styling across all input fields

Browser autofill styling is notoriously difficult to override 

_Trick_
It Suppress browser's autofill background paint

```
 transition: background-color 5000s ease-in-out 0s !important;
```


Before

https://github.com/user-attachments/assets/c33bd99f-25db-48ac-97ec-b1dcd6aed8f7


After

https://github.com/user-attachments/assets/22cf9897-c748-41e5-8966-79a16589874e

