### PR TITLE
fix: add consistent padding to author filter buttons

### DIFF
--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -91,7 +91,7 @@ function FilterPopover({
                     variant="ghost"
                     onClick={() => onAuthorChange?.(null)}
                     className={cn(
-                      "w-full justify-start text-left flex items-center space-x-3 hover:bg-zinc-100 dark:hover:bg-zinc-800",
+                      "w-full justify-start text-left flex items-center space-x-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 px-3 py-2 h-auto",
                       !selectedAuthor &&
                         "bg-blue-50  hover:bg-blue-50 text-sky-600 dark:text-zinc-200 dark:bg-zinc-800"
                     )}
@@ -111,7 +111,7 @@ function FilterPopover({
                       variant="ghost"
                       onClick={() => onAuthorChange?.(author.id)}
                       className={cn(
-                        "w-full justify-start text-left flex items-center space-x-3 hover:bg-zinc-100 dark:hover:bg-zinc-800",
+                        "w-full justify-start text-left flex items-center space-x-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 px-3 py-2 h-auto",
                         selectedAuthor === author.id &&
                           "bg-blue-50 dark:bg-zinc-800 hover:bg-blue-50 text-blue-600 dark:text-zinc-200"
                       )}


### PR DESCRIPTION
## Fix consistent padding for author filter buttons

### Fixes #411

### Problem
Author filter buttons in the FilterPopover had inconsistent padding, making them appear cramped.

### Solution
Added `px-3 py-2 h-auto` to both "All authors" and individual author buttons for consistent spacing.

### Changes
- `components/ui/filter-popover.tsx`: Added consistent padding classes to author filter buttons

### Screenshots

#### Before 
<img width="326" height="220" alt="Screenshot 2025-09-10 at 1 11 15 AM" src="https://github.com/user-attachments/assets/415c7213-cbd0-4b02-a7bc-08ee5e01e2b1" />

#### After

<img width="322" height="240" alt="Screenshot 2025-09-10 at 1 11 50 AM" src="https://github.com/user-attachments/assets/d47b33d3-6257-410c-a1a8-a8ac59469d1e" />


### Type of Change
- [x] Bug fix