### PR TITLE
fix: disable search when no note are created

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -826,17 +826,20 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             {/* Search Box */}
             <div className="relative h-9">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <Search className="h-4 w-4 text-muted-foreground dark:text-zinc-400" />
+                <Search
+                  className={`h-4 w-4 text-muted-foreground dark:text-zinc-400 ${notes.length === 0 ? "opacity-30" : ""}`}
+                />
               </div>
               <input
                 aria-label="Search notes"
                 type="text"
-                placeholder="Search notes..."
+                placeholder={notes.length === 0 ? "No notes to search" : "Search notes..."}
                 value={searchTerm}
+                disabled={notes.length === 0}
                 onChange={(e) => {
                   setSearchTerm(e.target.value);
                 }}
-                className="w-full pl-10 pr-8 py-2 border border-zinc-100 dark:border-zinc-800 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-600 dark:focus:ring-sky-600 focus:border-transparent text-sm bg-background dark:bg-zinc-900 text-foreground dark:text-zinc-100 placeholder:text-muted-foreground dark:placeholder:text-zinc-400"
+                className="w-full pl-10 pr-8 py-2 border border-zinc-100 dark:border-zinc-800 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-600 dark:focus:ring-sky-600 focus:border-transparent text-sm bg-background dark:bg-zinc-900 text-foreground dark:text-zinc-100 placeholder:text-muted-foreground dark:placeholder:text-zinc-400 disabled:opacity-30"
               />
               {searchTerm && (
                 <Button

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -308,4 +308,26 @@ test.describe("Search Functionality", () => {
     const newNoteTextarea = authenticatedPage.locator("textarea").first();
     await expect(newNoteTextarea).toBeVisible();
   });
+
+  test("should disable search when there are no notes", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const boardName = testContext.getBoardName("Empty Board Search Test");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("Empty board for search test"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    const searchInput = authenticatedPage.locator('input[placeholder="No notes to search"]');
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toBeDisabled();
+  });
 });


### PR DESCRIPTION
currently we have a small bug where a person can search in a empty board which causes unnecessary renders. 

before:

https://github.com/user-attachments/assets/7068c63c-aa8e-45b6-910f-44e8fdce7527


after:

https://github.com/user-attachments/assets/e29532df-7e5d-4523-a8ab-4cdb725a6424


test:
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/014246d9-ac91-416d-a5b4-b4992c5711f9" />

## use of AI
not in this pr