### PR TITLE
fix/checklist-backspace-navigation

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -28,6 +28,7 @@ interface ChecklistItemProps {
   className?: string;
   isNewItem?: boolean;
   onCreateItem?: (content: string) => void;
+  onNavigateToPrevious?: (itemId: string) => void;
 }
 
 export function ChecklistItem({
@@ -45,6 +46,7 @@ export function ChecklistItem({
   className,
   isNewItem = false,
   onCreateItem,
+  onNavigateToPrevious,
 }: ChecklistItemProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const previousContentRef = React.useRef<string>("");
@@ -86,7 +88,11 @@ export function ChecklistItem({
     }
     if (e.key === "Backspace" && editContent?.trim() === "") {
       e.preventDefault();
-      onDelete?.(item.id);
+      if (onNavigateToPrevious && !isNewItem) {
+        onNavigateToPrevious(item.id);
+      } else {
+        onDelete?.(item.id);
+      }
     }
   };
 

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -334,17 +334,17 @@ export function Note({
 
   const handleNavigateToPrevious = (currentItemId: string) => {
     if (!note.checklistItems) return;
-    
-    const currentIndex = note.checklistItems.findIndex(item => item.id === currentItemId);
+
+    const currentIndex = note.checklistItems.findIndex((item) => item.id === currentItemId);
     if (currentIndex > 0) {
       const previousItem = note.checklistItems[currentIndex - 1];
       const previousItemContent = previousItem.content;
-      
+
       navigationRef.current = {
         itemId: previousItem.id,
-        content: previousItemContent
+        content: previousItemContent,
       };
-      
+
       handleDeleteChecklistItem(currentItemId);
     } else {
       handleDeleteItem(currentItemId);
@@ -355,12 +355,14 @@ export function Note({
     if (navigationRef.current) {
       const { itemId, content } = navigationRef.current;
       navigationRef.current = null;
-      
+
       setEditingItem(itemId);
       setEditingItemContent(content);
-      
+
       requestAnimationFrame(() => {
-        const textarea = document.querySelector(`[data-testid="${itemId}"] textarea`) as HTMLTextAreaElement;
+        const textarea = document.querySelector(
+          `[data-testid="${itemId}"] textarea`
+        ) as HTMLTextAreaElement;
         if (textarea) {
           textarea.focus();
           textarea.setSelectionRange(content.length, content.length);


### PR DESCRIPTION
#411 

## Problem
When users pressed backspace on an empty todo item, the item would be deleted but the cursor wouldn't automatically navigate to the previous item. This broke the continuous backspace flow

## Solution
Implemented automatic navigation to the previous checklist item after deletion, allowing users to seamlessly backspace through multiple todo items in sequence.

## Preview
Before

https://github.com/user-attachments/assets/c3fc018c-713c-4f48-acaa-50ed63e0fb83



After

https://github.com/user-attachments/assets/f31038c8-70fd-431d-a7b6-8b65de56ab1e


> **Note**
> 
> AI Disclosure: Cursor AI was used to make minimal changes.
> Self-review: Comments from self-review have been added.
