### PR TITLE
Prevent unauthorized users from toggling checklist items

### DIFF
--- a/components/note.tsx
+++ b/components/note.tsx
@@ -92,7 +92,7 @@ export function Note({
 
   const handleToggleChecklistItem = async (itemId: string) => {
     try {
-      if (!note.checklistItems) return;
+      if (!note.checklistItems || !canEdit) return;
 
       const updatedItems = note.checklistItems.map((item) =>
         item.id === itemId ? { ...item, checked: !item.checked } : item


### PR DESCRIPTION
### Explanation of Change
Early return `handleToggleChecklistItem` function if `!canEdit`, so checklist items are only clickable for authorized users

### Screenshots/Videos
Before (The checklist is clickable)

https://github.com/user-attachments/assets/dfe4bd1f-d002-4670-b4cb-60c4d1f0efe0

After (The checklist is not clickable)

https://github.com/user-attachments/assets/523f7bca-6fb3-41f2-be3f-e90d25f6e5d1

### AI Disclosure
No AI tools used