### PR TITLE
fix: toaster instead of dialog when we copy link

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -17,11 +17,12 @@ import {
   ShieldCheck,
   Link,
   Copy,
+  Check,
   CalendarIcon,
   Users,
   ExternalLink,
+  Calendar as CalendarIconLucide,
 } from "lucide-react";
-import { Calendar as CalendarIconLucide } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
 import {
   AlertDialog,
@@ -38,6 +39,7 @@ import { useUser } from "@/app/contexts/UserContext";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useRouter } from "next/navigation";
 import { SLACK_WEBHOOK_REGEX } from "@/lib/constants";
+import { toast } from "sonner";
 
 interface OrganizationInvite {
   id: string;
@@ -97,6 +99,7 @@ export default function OrganizationSettingsPage() {
     variant?: "default" | "success" | "error";
   }>({ open: false, title: "", description: "", variant: "error" });
   const [creating, setCreating] = useState(false);
+  const [copiedInviteToken, setCopiedInviteToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (user?.organization) {
@@ -423,12 +426,9 @@ export default function OrganizationSettingsPage() {
     const inviteUrl = `${window.location.origin}/join/${inviteToken}`;
     try {
       await navigator.clipboard.writeText(inviteUrl);
-      setErrorDialog({
-        open: true,
-        title: "Success",
-        description: "Invite link copied to clipboard!",
-        variant: "success",
-      });
+      toast("Invite link copied to clipboard!");
+      setCopiedInviteToken(inviteToken);
+      setTimeout(() => setCopiedInviteToken(null), 3000);
     } catch (error) {
       console.error("Failed to copy link:", error);
       // Fallback for older browsers
@@ -438,12 +438,9 @@ export default function OrganizationSettingsPage() {
       textArea.select();
       document.execCommand("copy");
       document.body.removeChild(textArea);
-      setErrorDialog({
-        open: true,
-        title: "Success",
-        description: "Invite link copied to clipboard!",
-        variant: "success",
-      });
+      toast("Invite link copied to clipboard!");
+      setCopiedInviteToken(inviteToken);
+      setTimeout(() => setCopiedInviteToken(null), 3000);
     }
   };
 
@@ -866,7 +863,11 @@ export default function OrganizationSettingsPage() {
                             className="text-blue-600 hover:text-blue-700 hover:bg-blue-50 dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-zinc-800"
                             title="Copy invite link"
                           >
-                            <Copy className="w-4 h-4" />
+                            {copiedInviteToken === invite.token ? (
+                              <Check className="w-4 h-4" data-testid="check-icon" />
+                            ) : (
+                              <Copy className="w-4 h-4" data-testid="copy-icon" />
+                            )}
                           </Button>
                           {user?.isAdmin && (
                             <Button

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -184,4 +184,42 @@ test.describe("Organization Settings", () => {
       "Only admins can update organization settings"
     );
   });
+
+  test("should copy invite link and show visual feedback", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const invite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: "Test Invite",
+        token: "test-token-123",
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+      },
+    });
+
+    await authenticatedPage.goto("/settings/organization");
+
+    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Self-Serve Invite Links")).toBeVisible();
+
+    const copyButton = authenticatedPage.locator(`[title="Copy invite link"]`).first();
+    await expect(copyButton.locator('svg[data-testid="copy-icon"]')).toBeVisible();
+
+    await authenticatedPage.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await copyButton.click();
+    await expect(authenticatedPage.locator("text=Invite link copied to clipboard!")).toBeVisible();
+
+    await expect(copyButton.locator('svg[data-testid="check-icon"]')).toBeVisible();
+
+    await authenticatedPage.waitForTimeout(3500);
+    await expect(copyButton.locator('svg[data-testid="copy-icon"]')).toBeVisible();
+
+    await testPrisma.organizationSelfServeInvite.delete({
+      where: { id: invite.id },
+    });
+  });
 });

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -255,41 +255,44 @@ test.describe("Organization Settings", () => {
     expect(orgAfterSlackUpdate?.name).toBe(updatedName); // Name should remain unchanged
     expect(orgAfterSlackUpdate?.slackWebhookUrl).toBe(slackWebhookUrl);
   });
-});
 
-test("should copy invite link and show visual feedback", async ({
-  authenticatedPage,
-  testContext,
-  testPrisma,
-}) => {
-  const invite = await testPrisma.organizationSelfServeInvite.create({
-    data: {
-      name: "Test Invite",
-      token: "test-token-123",
-      organizationId: testContext.organizationId,
-      createdBy: testContext.userId,
-      isActive: true,
-    },
-  });
+  test("should copy invite link and show visual feedback", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const invite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: "Test Invite",
+        token: "test-token-123",
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+      },
+    });
 
-  await authenticatedPage.goto("/settings/organization");
+    await authenticatedPage.goto("/settings/organization");
 
-  await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
-  await expect(authenticatedPage.locator("text=Self-Serve Invite Links")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await expect(authenticatedPage.locator("text=Self-Serve Invite Links")).toBeVisible();
 
-  const copyButton = authenticatedPage.locator(`[title="Copy invite link"]`).first();
-  await expect(copyButton.locator('svg[data-testid="copy-icon"]')).toBeVisible();
+    const copyButton = authenticatedPage.locator(`[title="Copy invite link"]`).first();
+    await expect(copyButton.locator('svg[data-testid="copy-icon"]')).toBeVisible();
 
-  await authenticatedPage.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await authenticatedPage.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 
-  await copyButton.click();
-  await expect(authenticatedPage.locator("text=Invite link copied to clipboard!")).toBeVisible();
-  await expect(copyButton.locator('svg[data-testid="check-icon"]')).toBeVisible();
+    await copyButton.click();
+    await expect(authenticatedPage.locator("text=Invite link copied to clipboard!")).toBeVisible();
 
-  await authenticatedPage.waitForTimeout(3500);
-  await expect(copyButton.locator('svg[data-testid="copy-icon"]')).toBeVisible();
+    const clipboardContent = await authenticatedPage.evaluate(async () => {
+      return await navigator.clipboard.readText();
+    });
+    const baseUrl = new URL(authenticatedPage.url()).origin;
+    const expectedInviteLink = `${baseUrl}/join/test-token-123`;
+    expect(clipboardContent).toBe(expectedInviteLink);
 
-  await testPrisma.organizationSelfServeInvite.delete({
-    where: { id: invite.id },
+    await testPrisma.organizationSelfServeInvite.delete({
+      where: { id: invite.id },
+    });
   });
 });


### PR DESCRIPTION
#411 
when we copy, showing a toaster instead of a dialog make much more sense. dialog is great when we want confirmation but in the case of copy we are not doing that. so keeping a toaster can enhance the UX by reducing the unnecessary extra steps in between.

> same as we did for delete of card  #332

### before:

https://github.com/user-attachments/assets/48ee1bb8-3b79-40ef-bad4-bba9bfd7e489

### after:

https://github.com/user-attachments/assets/4d6f9658-ab57-4453-b9ff-82d48b2386bf

### test:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/cb49ea6b-1f80-44d8-b048-c54a13a55718" />

## use of ai
took help of cursor (claude 4)  to validate e2e test. 
test is self reviewed.