### PR TITLE
perf: parallelize API calls in public board and dashboard pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -85,7 +85,11 @@ export default function Dashboard() {
 
   const fetchUserAndBoards = useCallback(async () => {
     try {
-      const userResponse = await fetch("/api/user");
+      const [userResponse, boardsResponse] = await Promise.all([
+        fetch("/api/user"),
+        fetch("/api/boards")
+      ]);
+
       if (userResponse.status === 401) {
         router.push("/auth/signin");
         return;
@@ -104,7 +108,6 @@ export default function Dashboard() {
         }
       }
 
-      const boardsResponse = await fetch("/api/boards");
       if (boardsResponse.ok) {
         const { boards } = await boardsResponse.json();
         setBoards(boards);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -87,7 +87,7 @@ export default function Dashboard() {
     try {
       const [userResponse, boardsResponse] = await Promise.all([
         fetch("/api/user"),
-        fetch("/api/boards")
+        fetch("/api/boards"),
       ]);
 
       if (userResponse.status === 401) {

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -54,7 +54,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
     try {
       const [boardResponse, notesResponse] = await Promise.all([
         fetch(`/api/boards/${boardId}`),
-        fetch(`/api/boards/${boardId}/notes`)
+        fetch(`/api/boards/${boardId}/notes`),
       ]);
 
       if (boardResponse.status === 404 || boardResponse.status === 403) {

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -52,7 +52,11 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
 
   const fetchBoardData = async () => {
     try {
-      const boardResponse = await fetch(`/api/boards/${boardId}`);
+      const [boardResponse, notesResponse] = await Promise.all([
+        fetch(`/api/boards/${boardId}`),
+        fetch(`/api/boards/${boardId}/notes`)
+      ]);
+
       if (boardResponse.status === 404 || boardResponse.status === 403) {
         setBoard(null);
         setLoading(false);
@@ -69,7 +73,6 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
         }
       }
 
-      const notesResponse = await fetch(`/api/boards/${boardId}/notes`);
       if (notesResponse.ok) {
         const { notes } = await notesResponse.json();
         setNotes(notes);


### PR DESCRIPTION
Parallelize sequential API calls to reduce page load times.
Under: #411 
Type:
Objective Improvement

- Use Promise.all() in public board page to fetch board and notes simultaneously  
- Use Promise.all() in dashboard to fetch user and boards simultaneously
- Reduces load time in both pages

AI DISCLOSURE
NO AI WAS USED