### PR TITLE
fix(UI): board selector dropdown items alignment and mobile overflow

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -712,11 +712,12 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               </PopoverTrigger>
 
               <PopoverContent
-                className="p-2 w-full sm:w-64 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
+                className="p-2 mt-2 w-[calc(100vw-1.75rem)] sm:w-80 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
                 align="start"
+                alignOffset={-10}
               >
                 <div className="flex flex-col gap-1">
-                  <div className="max-h-50 overflow-y-auto">
+                  <div className="max-h-[50dvh] overflow-y-auto">
                     {allBoards.map((b) => (
                       <Link
                         key={b.id}


### PR DESCRIPTION
## Board Selector Alignment  Fix -  Ref #411

The visual heirarchy on pop-over list is a bit off for both desktop and mobile screens. 

This PR aligns the text items in a vertical line

### Issues Fixed:
- [x] Fixed board selector dropdown items alignment
- [x] Prevented mobile popover from overflowing screen boundaries

### Supplementary Changes

- [x] Increases max-height for board list to use available screen space 

### Visuals

#### Clean shots of the change

|Mobile|Desktop|
|-------|---------|
|<img width="344" height="764" alt="" src="https://github.com/user-attachments/assets/2fcdb0a4-8813-4d3d-b617-b07ea2862f0d" /> | <img width="1470" height="830" alt="Screenshot 2025-09-10 at 11 30 20 PM" src="https://github.com/user-attachments/assets/2ca9fd5e-964b-4488-bbbd-98430b7b2410" />|


#### Alignment shots
|Device| **Before** | **After** |
|--------|------------|-----------|
|Mobile| <img width="342" height="761" alt="bef_mob" src="https://github.com/user-attachments/assets/af458321-b601-4e7a-8f7a-20c1e3f8cafa" /> | <img width="342" height="761" alt="after_mob" src="https://github.com/user-attachments/assets/dffd9ad6-74d8-4415-8df5-cfc03deafe4c" />|
|Desktop| <img width="427" height="827" alt="bef_desk" src="https://github.com/user-attachments/assets/47b3bdc2-f7bd-45cb-9af1-82b8b1d98f93" /> | <img width="527" height="827" alt="after_desk" src="https://github.com/user-attachments/assets/a65ee3a7-9cbf-424a-a531-22b38c626def" />|


### AI Usage:
None
