### PR TITLE
feat: add tooltip to filter button in FilterPopover

### DIFF
--- a/components/ui/filter-popover.tsx
+++ b/components/ui/filter-popover.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { DateRangePicker } from "./date-range-picker";
 import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 interface FilterPopoverProps {
   startDate?: Date | null;
@@ -47,26 +48,34 @@ function FilterPopover({
   return (
     <div className={cn("relative", className)}>
       <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            disabled={disabled}
-            className={cn(
-              "flex items-center text-sm py-2",
-              filterCount > 0 ? "gap-1" : "gap-0",
-              disabled && "opacity-50 cursor-not-allowed"
-            )}
-          >
-            <ListFilter className="w-4 h-4 text-muted-foreground" />
-            <span className="text-foreground">
-              {filterCount > 0 && (
-                <span className="px-1.5 py-0.5 text-xs bg-sky-100 dark:bg-sky-500/20 text-sky-600 dark:text-sky-400 rounded">
-                  {filterCount}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                aria-label="Filters"
+                variant="ghost"
+                disabled={disabled}
+                className={cn(
+                  "flex items-center text-sm py-2",
+                  filterCount > 0 ? "gap-1" : "gap-0",
+                  disabled && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                <ListFilter className="w-4 h-4 text-muted-foreground" />
+                <span className="text-foreground">
+                  {filterCount > 0 && (
+                    <span className="px-1.5 py-0.5 text-xs bg-sky-100 dark:bg-sky-500/20 text-sky-600 dark:text-sky-400 rounded">
+                      {filterCount}
+                    </span>
+                  )}
                 </span>
-              )}
-            </span>
-          </Button>
-        </PopoverTrigger>
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Filters</p>
+          </TooltipContent>
+        </Tooltip>
         <PopoverContent className="w-full sm:w-80">
           <div className="space-y-4">
             <div className="space-y-2">

--- a/tests/e2e/filter-tooltip.spec.ts
+++ b/tests/e2e/filter-tooltip.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Filter tooltip", () => {
+  test("shows 'Filters' tooltip on hover", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/boards/all-notes");
+
+    const filterButton = authenticatedPage.getByRole("button", { name: "Filters" });
+    await expect(filterButton).toBeVisible();
+
+    await filterButton.hover();
+
+    await expect(
+      authenticatedPage.locator('[data-slot="tooltip-content"]:has-text("Filters")')
+    ).toBeVisible();
+  });
+});
+

--- a/tests/e2e/filter-tooltip.spec.ts
+++ b/tests/e2e/filter-tooltip.spec.ts
@@ -14,4 +14,3 @@ test.describe("Filter tooltip", () => {
     ).toBeVisible();
   });
 });
-


### PR DESCRIPTION
ref: #411 

### Summary:
-  Introduced a tooltip that displays "Filters" when hovering over the filter button in the FilterPopover component.
- Before: 

<img width="201" height="188" alt="Screenshot From 2025-09-10 00-38-33" src="https://github.com/user-attachments/assets/53b98cbe-1aee-4707-9160-6c2ea0910d66" />

- After: 

<img width="370" height="199" alt="Screenshot From 2025-09-10 16-03-47" src="https://github.com/user-attachments/assets/f1bf6f7e-c24d-43da-aa01-e59bf542c75e" />

<img width="633" height="357" alt="Screenshot From 2025-09-10 16-05-31" src="https://github.com/user-attachments/assets/fda1dd6f-df01-49fb-a0bf-0c42d2968239" />

### AI USAGE:
- No AI was used to generate any of this code.

### Self Review: 
- All changes are intuitive, so no additional comments are needed.
