### PR TITLE
fix: Remove delay from archive operations

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -81,8 +81,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     description: string;
   }>({ open: false, title: "", description: "" });
   const pendingDeleteTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-  const pendingArchiveTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-  const pendingUnarchiveTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const [boardSettingsDialog, setBoardSettingsDialog] = useState(false);
   const [boardSettings, setBoardSettings] = useState({
     name: "",
@@ -250,7 +248,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           fetch(`/api/boards/archive/notes`),
         ]);
 
-        // Set virtual board immediately
         setBoard({
           id: "archive",
           name: "Archive",
@@ -450,14 +447,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
     setNotes((prev) => prev.filter((n) => n.id !== noteId));
 
-    const timeoutId = setTimeout(async () => {
-      try {
-        const response = await fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ archivedAt: new Date().toISOString() }),
-        });
-
+    // Archive immediately instead of after 4 seconds
+    fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archivedAt: new Date().toISOString() }),
+    })
+      .then(response => {
         if (!response.ok) {
           setNotes((prev) => [currentNote, ...prev]);
           setErrorDialog({
@@ -466,7 +462,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             description: "Failed to archive note. Please try again.",
           });
         }
-      } catch (error) {
+      })
+      .catch(error => {
         console.error("Error archiving note:", error);
         setNotes((prev) => [currentNote, ...prev]);
         setErrorDialog({
@@ -474,23 +471,23 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           title: "Archive Failed",
           description: "Failed to archive note. Please try again.",
         });
-      } finally {
-        delete pendingArchiveTimeoutsRef.current[noteId];
-      }
-    }, 4000);
-
-    pendingArchiveTimeoutsRef.current[noteId] = timeoutId;
+      });
 
     toast("Note archived", {
       action: {
         label: "Undo",
-        onClick: () => {
-          const t = pendingArchiveTimeoutsRef.current[noteId];
-          if (t) {
-            clearTimeout(t);
-            delete pendingArchiveTimeoutsRef.current[noteId];
-          }
+        onClick: async () => {
           setNotes((prev) => [currentNote, ...prev]);
+          try {
+            await fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ archivedAt: null }),
+            });
+          } catch (error) {
+            console.error("Error undoing archive:", error);
+            setNotes((prev) => prev.filter((n) => n.id !== noteId));
+          }
         },
       },
       duration: 4000,
@@ -506,14 +503,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
     setNotes((prev) => prev.filter((n) => n.id !== noteId));
 
-    const timeoutId = setTimeout(async () => {
-      try {
-        const response = await fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ archivedAt: null }),
-        });
-
+    // Unarchive immediately instead of after 4 seconds
+    fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archivedAt: null }),
+    })
+      .then(response => {
         if (!response.ok) {
           setNotes((prev) => [currentNote, ...prev]);
           setErrorDialog({
@@ -522,7 +518,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             description: "Failed to unarchive note. Please try again.",
           });
         }
-      } catch (error) {
+      })
+      .catch(error => {
         console.error("Error unarchiving note:", error);
         setNotes((prev) => [currentNote, ...prev]);
         setErrorDialog({
@@ -530,23 +527,23 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           title: "Unarchive Failed",
           description: "Failed to unarchive note. Please try again.",
         });
-      } finally {
-        delete pendingUnarchiveTimeoutsRef.current[noteId];
-      }
-    }, 4000);
-
-    pendingUnarchiveTimeoutsRef.current[noteId] = timeoutId;
+      });
 
     toast("Note unarchived", {
       action: {
         label: "Undo",
-        onClick: () => {
-          const t = pendingUnarchiveTimeoutsRef.current[noteId];
-          if (t) {
-            clearTimeout(t);
-            delete pendingUnarchiveTimeoutsRef.current[noteId];
-          }
+        onClick: async () => {
           setNotes((prev) => [currentNote, ...prev]);
+          try {
+            await fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ archivedAt: new Date().toISOString() }),
+            });
+          } catch (error) {
+            console.error("Error undoing unarchive:", error);
+            setNotes((prev) => prev.filter((n) => n.id !== noteId));
+          }
         },
       },
       duration: 4000,

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -453,7 +453,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ archivedAt: new Date().toISOString() }),
     })
-      .then(response => {
+      .then((response) => {
         if (!response.ok) {
           setNotes((prev) => [currentNote, ...prev]);
           setErrorDialog({
@@ -463,7 +463,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         console.error("Error archiving note:", error);
         setNotes((prev) => [currentNote, ...prev]);
         setErrorDialog({
@@ -509,7 +509,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ archivedAt: null }),
     })
-      .then(response => {
+      .then((response) => {
         if (!response.ok) {
           setNotes((prev) => [currentNote, ...prev]);
           setErrorDialog({
@@ -519,7 +519,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         console.error("Error unarchiving note:", error);
         setNotes((prev) => [currentNote, ...prev]);
         setErrorDialog({


### PR DESCRIPTION
## Summary

Fix archive state update issue where archived notes don't appear immediately in the archive view.

Part of: #411

## Problem

When users archive a note and navigate to the archive page, the archived note doesn't appear until the page is manually refreshed. This creates a confusing UX where users think the archive operation failed.

## Root Cause

The archive/unarchive operations were delayed by 4 seconds (using `setTimeout`) to allow for undo functionality. When users navigate to the archive page immediately after archiving, the note hasn't been archived in the database yet.

## Solution

Made archive and unarchive operations execute immediately while preserving the undo functionality through the toast notification.

## Changes

- Removed 4-second delay from `handleArchiveNote` and `handleUnarchiveNote` functions
- Archive/unarchive API calls now execute immediately
- Toast with undo option still displays for 4 seconds
- Removed unused `pendingArchiveTimeoutsRef` and `pendingUnarchiveTimeoutsRef`

## Demo

### Before

https://github.com/user-attachments/assets/a7c647cd-0489-4675-a969-f8aed64840ac

### After

https://github.com/user-attachments/assets/73a2d20f-088f-45b8-8911-f86c87132022

## Testing

1. Archive a note from any board
2. Navigate immediately to the archive page
3. ✅ Archived note appears without needing to refresh
4. ✅ Undo functionality still works via toast notification

## Impact

- **Before**: Users had to refresh the archive page to see newly archived notes
- **After**: Archive page shows updated content immediately
- **No breaking changes**: All existing functionality preserved

#### AI disclosure 
NO AI used