### PR TITLE
fix: toast message when we change the username

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Mail, Trash2, AlertTriangle } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
+import { toast } from "sonner";
 
 import {
   AlertDialog,
@@ -73,8 +74,11 @@ export default function ProfileSettingsPage() {
       if (response.ok) {
         await refreshUser();
         setProfileName(profileName.trim());
+        toast.success("Profile updated successfully");
       }
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+      toast.error(`Failed to save profile: ${errorMessage}`);
       console.error("Error updating profile:", error);
     } finally {
       setSaving(false);


### PR DESCRIPTION
#411 
currently we dont show any visual cue when we make change in the username. added toast message so that the end user can get whether his username is changed or not visually. it kind of doesn't bother when it is success but when error occurs. it really hampers the UX leading the end user in confusion.

## before:

https://github.com/user-attachments/assets/ec4aace8-3f25-44bc-a7fc-8dee026b842c


## after
### when error


https://github.com/user-attachments/assets/27640beb-9572-4fab-bd95-7d5bebb5b2d0


### when success


https://github.com/user-attachments/assets/9c855702-942c-4f93-b22d-9ea301368dfb


## use of AI
not in this pr