### PR TITLE
fix: width fit added for accessibility

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -681,7 +681,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         <div className="mx-0.5 md:mx-5 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-2 items-center h-auto md:h-16 p-2 md:p-0">
           <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 md:w-fit grid grid-cols-[1fr_auto] md:grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Company Name */}
-            <Link href="/dashboard" className="flex-shrink-0 pl-1">
+            <Link href="/dashboard" className="flex-shrink-0 pl-1 w-fit">
               <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-3">
                 Gumboard
                 <BetaBadge />


### PR DESCRIPTION
 the width of the Link was full making it prone to accidental click in in smaller screen
 
> added border to visualize the changes

### before:
<img width="620" height="768" alt="Screenshot 2025-09-10 at 7 43 56 PM" src="https://github.com/user-attachments/assets/48751ef4-eb6e-4cab-8516-a30afbddfe1e" />
### after:
<img width="487" height="654" alt="Screenshot 2025-09-10 at 7 45 34 PM" src="https://github.com/user-attachments/assets/18861336-148f-42db-8315-fe0e67724ba6" />

## use of ai
not in this pr