### PR TITLE
fix: stats section responsive ui

### DIFF
--- a/components/stats-section.tsx
+++ b/components/stats-section.tsx
@@ -56,10 +56,10 @@ export function StatsSection() {
           </p>
         </div>
 
-        <div className="flex flex-col lg:flex-row items-center justify-center gap-4 lg:gap-6">
+        <div className="flex flex-col lg:flex-row items-center justify-center gap-4 xl:gap-6">
           {statsData.map((stat, index) => (
             <React.Fragment key={stat.key}>
-              <Card className="bg-white dark:bg-zinc-800 border-gray-200 dark:border-zinc-700 w-full lg:w-auto lg:min-w-[180px]">
+              <Card className="bg-white dark:bg-zinc-800 border-gray-200 dark:border-zinc-700 w-full lg:w-auto lg:min-w-[150px] xl:min-w-[180px]">
                 <CardHeader className="pb-2 text-center">
                   <CardDescription className="text-xs text-gray-600 dark:text-gray-400">
                     {stat.label}
@@ -70,7 +70,7 @@ export function StatsSection() {
                 </CardHeader>
               </Card>
               {index < statsData.length - 1 && (
-                <ArrowRight className="hidden lg:block w-6 h-6 text-gray-400 dark:text-zinc-500" />
+                <ArrowRight className="hidden lg:block size-5 text-gray-400 dark:text-zinc-500" />
               )}
             </React.Fragment>
           ))}


### PR DESCRIPTION
### Description:

UI is not responsive for stats section on homepage between `lg` and `xl` screen causing 2 issues:
- Cards overflow
- Arrow disappear and appear based on screen size

Part of #411 

### Before / After:

#### Before:

https://github.com/user-attachments/assets/ed4d6c84-bdd0-44cd-864d-77cf43603d41


#### After:


https://github.com/user-attachments/assets/124a648d-a9db-40be-8625-ee5d626ce1b4


https://github.com/user-attachments/assets/476708b2-119d-4e65-9e94-e5a8d3acad14


### Test Suite / Related tests:

CSS change, no impact on tests.

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.
> Self-review: All changes are intuitive, so no additional comments are needed.