### PR TITLE
fix: move close button to the dialog header

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { ChevronDown, Search, Copy, Trash2, X, EllipsisVertical } from "lucide-react";
+import { ChevronDown, Search, Copy, Trash2, X, EllipsisVertical, XIcon } from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { FilterPopover } from "@/components/ui/filter-popover";
@@ -1019,6 +1019,15 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       <AlertDialog open={boardSettingsDialog} onOpenChange={setBoardSettingsDialog}>
         <AlertDialogContent className="board-settings-modal bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 p-4 lg:p-6">
           <AlertDialogHeader>
+            <AlertDialogCancel asChild>
+            <Button
+              className="absolute right-4 top-3 md:right-4 md:top-5 border-0 p-1"
+              aria-label="Close"
+              title="close"
+            >
+              <XIcon className="text-4" />
+            </Button>
+          </AlertDialogCancel>
             <AlertDialogTitle className="text-foreground dark:text-zinc-100">
               Board settings
             </AlertDialogTitle>
@@ -1132,18 +1141,16 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           </div>
 
           <AlertDialogFooter className="flex !flex-row justify-between">
-            <Button
+           
+            <div className="flex gap-2 items-center">
+              <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
               className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-            >
-              <Trash2 className="w-4 h-4" />
-              <span className="hidden lg:inline">Delete Board</span>
-            </Button>
-            <div className="flex space-x-2 items-center">
-              <AlertDialogCancel className="border-gray-400 text-foreground dark:text-zinc-100 dark:border-zinc-700 hover:bg-zinc-100 hover:text-foreground hover:border-gray-200 dark:hover:bg-zinc-800">
-                Cancel
-              </AlertDialogCancel>
+              >
+                <Trash2 className="w-4 h-4" />
+                <span className="hidden lg:inline">Delete Board</span>
+              </Button>
               <AlertDialogAction
                 onClick={() => handleUpdateBoardSettings(boardSettings)}
                 className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-500 dark:hover:bg-blue-600 dark:text-white"

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -12,7 +12,8 @@ import {
   Copy,
   Trash2,
   X,
-  EllipsisVertical, XIcon,
+  EllipsisVertical,
+  XIcon,
   StickyNote,
   Plus,
 } from "lucide-react";
@@ -1070,14 +1071,14 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         <AlertDialogContent className="board-settings-modal bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 p-4 lg:p-6">
           <AlertDialogHeader>
             <AlertDialogCancel asChild>
-            <Button
-              className="absolute right-4 top-3 md:right-4 md:top-5 border-0 p-1"
-              aria-label="Close"
-              title="close"
-            >
-              <XIcon className="text-4" />
-            </Button>
-          </AlertDialogCancel>
+              <Button
+                className="absolute right-4 top-3 md:right-4 md:top-5 border-0 p-1"
+                aria-label="Close"
+                title="close"
+              >
+                <XIcon className="text-4" />
+              </Button>
+            </AlertDialogCancel>
             <AlertDialogTitle className="text-foreground dark:text-zinc-100">
               Board settings
             </AlertDialogTitle>
@@ -1192,21 +1193,21 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           </div>
 
           <AlertDialogFooter className="flex !flex-row justify-start md:justify-between">
-             <Button
+            <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
               className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-              >
-                <Trash2 className="w-4 h-4" />
-                <span className="hidden lg:inline">Delete Board</span>
-              </Button>
-          
-              <AlertDialogAction
-                onClick={() => handleUpdateBoardSettings(boardSettings)}
-                className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-500 dark:hover:bg-blue-600 dark:text-white"
-              >
-                Save settings
-              </AlertDialogAction>
+            >
+              <Trash2 className="w-4 h-4" />
+              <span className="hidden lg:inline">Delete Board</span>
+            </Button>
+
+            <AlertDialogAction
+              onClick={() => handleUpdateBoardSettings(boardSettings)}
+              className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-500 dark:hover:bg-blue-600 dark:text-white"
+            >
+              Save settings
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1191,24 +1191,22 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             </p>
           </div>
 
-          <AlertDialogFooter className="flex !flex-row justify-between">
-           
-            <div className="flex gap-2 items-center">
-              <Button
+          <AlertDialogFooter className="flex !flex-row justify-start md:justify-between">
+             <Button
               onClick={() => setDeleteConfirmDialog(true)}
               variant="destructive"
-              className="mr-auto flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
+              className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
               >
                 <Trash2 className="w-4 h-4" />
                 <span className="hidden lg:inline">Delete Board</span>
               </Button>
+          
               <AlertDialogAction
                 onClick={() => handleUpdateBoardSettings(boardSettings)}
                 className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-500 dark:hover:bg-blue-600 dark:text-white"
               >
                 Save settings
               </AlertDialogAction>
-            </div>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/tests/e2e/board-settings.spec.ts
+++ b/tests/e2e/board-settings.spec.ts
@@ -183,7 +183,7 @@ test.describe("Board Settings", () => {
     await checkbox.uncheck();
     await expect(checkbox).not.toBeChecked();
 
-    await authenticatedPage.click('button:has-text("Cancel")');
+    await authenticatedPage.getByTitle("close").click();
 
     await expect(authenticatedPage.locator("text=Board settings")).not.toBeVisible();
 


### PR DESCRIPTION
ref: #411 
part of #715 
### Description
- removed the closed button from the footer to the top.



### Before:

<img width="599" height="566" alt="image" src="https://github.com/user-attachments/assets/11b02811-c6c6-486d-ab01-d427952a926c" />


### After: 

<img width="599" height="566" alt="image" src="https://github.com/user-attachments/assets/393bfdf0-a2e6-4038-8f32-9ffa86eeb2b0" />



### Test 

<img width="947" height="154" alt="image" src="https://github.com/user-attachments/assets/54bafdc7-7d6b-4732-ba2f-0f3ee5316499" />

