### PR TITLE
fix: replace board description input with textarea

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1044,14 +1044,15 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               <label className="block text-sm font-medium text-foreground dark:text-zinc-200 mb-1">
                 Description (optional)
               </label>
-              <Input
-                type="text"
+              <textarea
                 value={boardSettings.description}
                 onChange={(e) =>
                   setBoardSettings((prev) => ({ ...prev, description: e.target.value }))
                 }
                 placeholder="Enter board description"
-                className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700"
+                className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 
+                w-full min-h-[80px] text-base md:text-sm rounded-md px-3 py-2 outline-none 
+                focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500 focus:border-blue-500"
               />
             </div>
             <div className="space-y-4">


### PR DESCRIPTION
ref: #411 
part of #715 
### Description
- Replace board description input with textarea for multiline support



### Before:

<img width="608" height="590" alt="image" src="https://github.com/user-attachments/assets/9b9829fb-ce7d-4c57-abc0-e4680b61d614" />


### After: 

<img width="608" height="590" alt="image" src="https://github.com/user-attachments/assets/9a24af39-fe92-45af-9f36-c03c9ffe1666" />

