### PR TITLE
fix: dimensions and color of switch 

### DIFF
--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -9,13 +9,13 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-blue-600 dark:data-[state=checked]:bg-blue-500 data-[state=unchecked]:bg-gray-300 dark:data-[state=unchecked]:bg-gray-600 hover:data-[state=unchecked]:bg-gray-400 dark:hover:data-[state=unchecked]:bg-gray-500",
+      "peer inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-sky-600 dark:data-[state=checked]:bg-sky-600 data-[state=unchecked]:bg-gray-300 dark:data-[state=unchecked]:bg-gray-600 hover:data-[state=unchecked]:bg-gray-400 dark:hover:data-[state=unchecked]:bg-gray-500",
       className
     )}
     {...props}
     ref={ref}
   >
-    <SwitchPrimitive.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ease-in-out data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5 dark:bg-gray-100" />
+  <SwitchPrimitive.Thumb className="pointer-events-none block h-3 w-3 rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ease-in-out data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0.5 dark:bg-gray-100" />
   </SwitchPrimitive.Root>
 ));
 Switch.displayName = SwitchPrimitive.Root.displayName;


### PR DESCRIPTION
ref: #411 
part of #715 

### Description
- Fixes the dimensions of switch.
- Fixes the color of switch icon.



### Before:

<img width="672" height="72" alt="image" src="https://github.com/user-attachments/assets/ab61bbcd-7abc-43ba-9e28-110dd3d7d911" />


### After: 

<img width="672" height="72" alt="image" src="https://github.com/user-attachments/assets/dbb348bd-29e9-4a64-95f6-11056c3df42c" />

