### PR TITLE
fix: replace input with textarea at create new board description

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -974,9 +974,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   <FormItem>
                     <FormLabel>Description (Optional)</FormLabel>
                     <FormControl>
-                      <Input
+                      <textarea
                         placeholder="Enter board description"
-                        className="border border-zinc-200 dark:border-zinc-800 text-muted-foreground dark:text-zinc-200"
+                        className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 
+                        w-full min-h-[60px] text-base md:text-sm rounded-md px-3 py-2 outline-none 
+                        focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500 focus:border-blue-500"
                         {...field}
                       />
                     </FormControl>


### PR DESCRIPTION
ref: #411 

### Description
- Replace create new board description input with textarea for multiline support.



### Before:

<img width="655" height="536" alt="image" src="https://github.com/user-attachments/assets/72d621fd-bc07-4ce8-9ed2-73ce8cd3c1b8" />

### After: 

<img width="655" height="536" alt="image" src="https://github.com/user-attachments/assets/f8c2c842-ac6b-413d-9625-7b77a8d1ceb3" />
