### PR TITLE
Sanitize public notes API: hide user email for unauthenticated requests

### DIFF
--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -54,6 +54,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     if (board.isPublic) {
+      const hasSession = !!session?.user?.id;
+      if (!hasSession) {
+        const sanitizedNotes = board.notes.map((n) => ({
+          ...n,
+          user: n.user
+            ? {
+                name: n.user.name ?? null,
+                image: n.user.image ?? null,
+              }
+            : null,
+        }));
+        return NextResponse.json({ notes: sanitizedNotes });
+      }
       return NextResponse.json({ notes: board.notes });
     }
 


### PR DESCRIPTION
Ref #411 

Emails can get exposed via public board link.

Repro steps:
1. To reproduce, one can declare a board public and get the public board url.
2. Hit this link with `curl -sS http://localhost:3000/api/boards/<board_id>/notes | jq`

This PR hides the mails when exposed via public board.

### Before
<img width="1167" height="934" alt="Screenshot 2025-09-10 at 10 34 25 PM" src="https://github.com/user-attachments/assets/ed2bcb7f-fe1f-475f-989f-4720ba9d2abd" />

### After
<img width="1119" height="816" alt="Screenshot 2025-09-10 at 10 35 04 PM" src="https://github.com/user-attachments/assets/24dba264-e577-4865-abc5-b755faab80c3" />


### AI disclosure
gpt-5 in cursor for assistance