### PR TITLE
fix: Add scrollable containers to invite sections in org settings

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -713,27 +713,27 @@ export default function OrganizationSettingsPage() {
               <div className="max-h-80 overflow-y-auto pr-1">
                 <div className="space-y-2">
                   {invites.map((invite) => (
-                <div
-                  key={invite.id}
-                  className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-900 rounded-lg border border-yellow-200 dark:border-yellow-800"
-                >
-                  <div className="min-w-0">
-                    <p className="font-medium text-zinc-900 dark:text-zinc-100 break-words">
-                      {invite.email}
-                    </p>
-                    <p className="text-sm text-zinc-600 dark:text-zinc-400">
-                      Invited on {new Date(invite.createdAt).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <Button
-                    onClick={() => handleCancelInvite(invite.id)}
-                    variant="outline"
-                    size="sm"
-                    className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400 border border-red-600 dark:border-red-500 font-medium px-4 py-2 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-60"
-                    disabled={cancellingInviteIds.includes(invite.id)}
-                  >
-                    {cancellingInviteIds.includes(invite.id) ? "Cancelling..." : "Cancel"}
-                  </Button>
+                    <div
+                      key={invite.id}
+                      className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-900 rounded-lg border border-yellow-200 dark:border-yellow-800"
+                    >
+                      <div className="min-w-0">
+                        <p className="font-medium text-zinc-900 dark:text-zinc-100 break-words">
+                          {invite.email}
+                        </p>
+                        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                          Invited on {new Date(invite.createdAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <Button
+                        onClick={() => handleCancelInvite(invite.id)}
+                        variant="outline"
+                        size="sm"
+                        className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400 border border-red-600 dark:border-red-500 font-medium px-4 py-2 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-60"
+                        disabled={cancellingInviteIds.includes(invite.id)}
+                      >
+                        {cancellingInviteIds.includes(invite.id) ? "Cancelling..." : "Cancel"}
+                      </Button>
                     </div>
                   ))}
                 </div>
@@ -874,30 +874,32 @@ export default function OrganizationSettingsPage() {
               <div className="max-h-135 overflow-y-auto pr-1">
                 <div className="space-y-3">
                   {selfServeInvites.map((invite) => (
-                <div
-                  key={invite.id}
-                  className={`p-4 bg-blue-50 dark:bg-zinc-800 rounded-lg border border-blue-200 dark:border-zinc-700 ${
-                    deletingInviteToken === invite.token
-                      ? "opacity-50 pointer-events-none transition-opacity duration-100"
-                      : ""
-                  } truncate max-w-full overflow-x-auto whitespace-nowrap`}
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center space-x-2">
-                          <h5 className="font-medium text-zinc-900 dark:text-zinc-100">
-                            {invite.name}
-                          </h5>
-                          {(invite.expiresAt ? new Date(invite.expiresAt) < new Date() : false) ? (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-                              Expired
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                              Active
-                            </span>
-                          )}
+                    <div
+                      key={invite.id}
+                      className={`p-4 bg-blue-50 dark:bg-zinc-800 rounded-lg border border-blue-200 dark:border-zinc-700 ${
+                        deletingInviteToken === invite.token
+                          ? "opacity-50 pointer-events-none transition-opacity duration-100"
+                          : ""
+                      } truncate max-w-full overflow-x-auto whitespace-nowrap`}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center space-x-2">
+                              <h5 className="font-medium text-zinc-900 dark:text-zinc-100">
+                                {invite.name}
+                              </h5>
+                              {(
+                                invite.expiresAt ? new Date(invite.expiresAt) < new Date() : false
+                              ) ? (
+                                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                                  Expired
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                  Active
+                                </span>
+                              )}
                             </div>
                             <div className="flex items-center space-x-2 ml-4">
                               <Button


### PR DESCRIPTION
## Fix Organization Settings Overflow with Scrollable Containers

##  Purpose
Fix UI overflow issues in Organization Settings when there are many pending invites or self-serve invite links.

Part of: #411 

## Problem
- Lists grew unbounded causing page layout breakage
- Poor UX with excessively long scrolling pages
- Content overflow on smaller screens

##  Solution
Added scrollable containers with defined max heights:
- **Pending Invites**: `max-h-80
- **Active Invite Links**: `max-h-135 

### Before

https://github.com/user-attachments/assets/85418851-0198-4df1-98f0-a9558e9de50c

### After

https://github.com/user-attachments/assets/64676d22-1a93-4b6b-99fc-f7268175379c

#### Tests
<img width="1008" height="498" alt="Screenshot 2025-09-10 at 10 39 44 PM" src="https://github.com/user-attachments/assets/023e3347-204b-4eca-963c-a7967014cdf0" />

<img width="1005" height="316" alt="Screenshot 2025-09-10 at 10 41 00 PM" src="https://github.com/user-attachments/assets/ff7bcc66-bc19-4320-a385-4a533d491326" />

All test cases related to the module are working fine.

AI disclosure 
No AI usage