### PR TITLE
feat(ui): better accessible `cancel` button

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -727,7 +727,7 @@ export default function OrganizationSettingsPage() {
                     onClick={() => handleCancelInvite(invite.id)}
                     variant="outline"
                     size="sm"
-                    className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900 border-red-600 hover:bg-inherit hover:border-red-600 disabled:opacity-70 disabled:text-red-300"
+                    className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400 border border-red-600 dark:border-red-500 font-medium px-4 py-2 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-60"
                     disabled={cancellingInviteIds.includes(invite.id)}
                   >
                     {cancellingInviteIds.includes(invite.id) ? "Cancelling..." : "Cancel"}


### PR DESCRIPTION
ref #411 

## Description
- made cancel button more accessible and color matching at `settings/organization`

Before:
<img width="447" height="118" alt="Screenshot 2025-09-10 at 10 58 15 PM" src="https://github.com/user-attachments/assets/ee4d861f-d02e-4fad-9af4-74d61df38578" />

After :
<img width="429" height="155" alt="Screenshot 2025-09-10 at 11 02 21 PM" src="https://github.com/user-attachments/assets/d9cc3774-f54f-4e3b-be8c-5724f6ec69a0" />

## AI disclosure
No AI usage

## Self Review
Have done self review from my side 
