### PR TITLE
fix(ui): removed unwanted scroll-container 

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -874,7 +874,7 @@ export default function OrganizationSettingsPage() {
                     deletingInviteToken === invite.token
                       ? "opacity-50 pointer-events-none transition-opacity duration-100"
                       : ""
-                  } truncate max-w-full overflow-scroll whitespace-nowrap`}
+                  } truncate max-w-full overflow-x-auto whitespace-nowrap`}
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">


### PR DESCRIPTION
ref #411 
Part of #739 

## Description
- removed the unwanted scroll container showing while not overflowing

Before:
<img width="1223" height="475" alt="Screenshot 2025-09-10 at 11 15 54 PM" src="https://github.com/user-attachments/assets/dc8d142c-176c-4442-a162-33afe08cf6a9" />


After :
<img width="1205" height="391" alt="Screenshot 2025-09-10 at 11 16 08 PM" src="https://github.com/user-attachments/assets/623040c0-4fc5-491b-872e-65be79b70abb" />

Small device : 
https://github.com/user-attachments/assets/4c48861d-4e23-4873-8a94-69f28e70ff6a



## AI disclosure
No AI usage

## Self Review
Have done self review from my side 
