### PR TITLE
ref(ui): org name update form refactor to shadcn forms 

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -220,6 +220,7 @@ export default function OrganizationSettingsPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          name: user?.organization?.name,
           slackWebhookUrl: slackWebhookUrl,
         }),
       });
@@ -614,6 +615,7 @@ export default function OrganizationSettingsPage() {
 
           <div className="pt-4 border-t border-zinc-200 dark:border-zinc-800">
             <Button
+              id="saveSlackWebhookButton"
               onClick={handleSaveSlack}
               disabled={
                 savingSlack || slackWebhookUrl === originalSlackWebhookUrl || !user?.isAdmin

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -43,7 +43,14 @@ import { toast } from "sonner";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { cn } from "@/lib/utils";
 
 interface OrganizationInvite {
@@ -68,7 +75,9 @@ interface SelfServeInvite {
   };
 }
 
-const organizationNameFormSchema = z.object({organizationName: z.string().min(1, "Organization name is required")})
+const organizationNameFormSchema = z.object({
+  organizationName: z.string().min(1, "Organization name is required"),
+});
 
 export default function OrganizationSettingsPage() {
   const { user, loading, refreshUser } = useUser();
@@ -171,7 +180,7 @@ export default function OrganizationSettingsPage() {
       });
 
       if (response.ok) {
-        organizationNameForm.reset(values)
+        organizationNameForm.reset(values);
         refreshUser();
       } else {
         const errorData = await response.json();
@@ -188,7 +197,7 @@ export default function OrganizationSettingsPage() {
         title: "Failed to update organization",
         description: "Failed to update organization",
       });
-    } 
+    }
   };
 
   const handleSaveSlack = async () => {
@@ -505,56 +514,58 @@ export default function OrganizationSettingsPage() {
             </p>
           </div>
           <Form {...organizationNameForm}>
-            <form onSubmit={organizationNameForm.handleSubmit(handleSaveOrgName)} className="space-y-6">
+            <form
+              onSubmit={organizationNameForm.handleSubmit(handleSaveOrgName)}
+              className="space-y-6"
+            >
               <FormField
-              control={organizationNameForm.control}
-              name="organizationName"
-              render={({ field, fieldState }) => (
-                <FormItem>
-                  <FormLabel className="text-zinc-800 dark:text-zinc-200">
-                    Organization Name
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="Enter organization name"
-                      disabled={!user?.isAdmin}
-                      className={cn(
-                            "bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100",
-                            fieldState.error && "border-red-500 dark:border-red-500 focus-visible:ring-red-500 dark:focus-visible:ring-red-500"
-                          )}
-                    />
-                  </FormControl>
-                  <FormMessage className="text-xs text-red-500 dark:text-red-400" />
-                </FormItem>
-              )}
-            />
-
-            <div className="pt-4 border-t border-zinc-200 dark:border-zinc-800">
-              <Button
-                type="submit"
-                disabled={
-                  organizationNameForm.formState.isSubmitting ||
-                  !organizationNameForm.formState.isDirty ||
-                  !user?.isAdmin
-                }
-                className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 disabled:bg-gray-400 disabled:cursor-not-allowed text-white dark:text-zinc-100"
-                title={
-                  !user?.isAdmin
-                    ? "Only admins can update organization settings"
-                    : undefined
-                }
-              >
-                {organizationNameForm.formState.isSubmitting ? (
-                  <>
-                  <Loader size="sm" className="animate-spin" />
-                  <span>Saving</span>
-                  </>
-                ): (
-                  "Save Changes"
+                control={organizationNameForm.control}
+                name="organizationName"
+                render={({ field, fieldState }) => (
+                  <FormItem>
+                    <FormLabel className="text-zinc-800 dark:text-zinc-200">
+                      Organization Name
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="Enter organization name"
+                        disabled={!user?.isAdmin}
+                        className={cn(
+                          "bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100",
+                          fieldState.error &&
+                            "border-red-500 dark:border-red-500 focus-visible:ring-red-500 dark:focus-visible:ring-red-500"
+                        )}
+                      />
+                    </FormControl>
+                    <FormMessage className="text-xs text-red-500 dark:text-red-400" />
+                  </FormItem>
                 )}
-              </Button>
-            </div>
+              />
+
+              <div className="pt-4 border-t border-zinc-200 dark:border-zinc-800">
+                <Button
+                  type="submit"
+                  disabled={
+                    organizationNameForm.formState.isSubmitting ||
+                    !organizationNameForm.formState.isDirty ||
+                    !user?.isAdmin
+                  }
+                  className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 disabled:bg-gray-400 disabled:cursor-not-allowed text-white dark:text-zinc-100"
+                  title={
+                    !user?.isAdmin ? "Only admins can update organization settings" : undefined
+                  }
+                >
+                  {organizationNameForm.formState.isSubmitting ? (
+                    <>
+                      <Loader size="sm" className="animate-spin" />
+                      <span>Saving</span>
+                    </>
+                  ) : (
+                    "Save Changes"
+                  )}
+                </Button>
+              </div>
             </form>
           </Form>
         </div>

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -167,6 +167,7 @@ export default function OrganizationSettingsPage() {
         },
         body: JSON.stringify({
           name: values.organizationName,
+          slackWebhookUrl: slackWebhookUrl,
         }),
       });
 

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -78,7 +78,7 @@ test.describe("Organization Settings", () => {
     await slackWebhookInput.fill(validSlackUrl);
 
     // Click save button for Slack integration
-    const slackSaveButton = authenticatedPage.locator('button:has-text("Save changes")').nth(1);
+    const slackSaveButton = authenticatedPage.locator('#saveSlackWebhookButton')
 
     // Wait for the save request to complete
     const saveResponse = authenticatedPage.waitForResponse(

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -78,7 +78,7 @@ test.describe("Organization Settings", () => {
     await slackWebhookInput.fill(validSlackUrl);
 
     // Click save button for Slack integration
-    const slackSaveButton = authenticatedPage.locator('#saveSlackWebhookButton')
+    const slackSaveButton = authenticatedPage.locator("#saveSlackWebhookButton");
 
     // Wait for the save request to complete
     const saveResponse = authenticatedPage.waitForResponse(


### PR DESCRIPTION
# Description

Updated the organization name input to use shadcn form with validation errors. If approved, I’ll refactor the remaining inputs to follow the same pattern.

## Before
Errors handled by dialog and no loading spinner 

https://github.com/user-attachments/assets/034abc08-92df-4ae5-961a-6ad483255ee9

## After (Light & Dark mode)
https://github.com/user-attachments/assets/fe29e32f-c3e7-4ed9-b702-82445efaad70

## AI Disclosure
No ai was used in this pr