### PR TITLE
fix: Center align remove button in organization setup form.

### DIFF
--- a/app/setup/organization/form.tsx
+++ b/app/setup/organization/form.tsx
@@ -80,7 +80,7 @@ export default function OrganizationSetupForm({ onSubmit }: OrganizationSetupFor
 
         <div className="space-y-3">
           {teamEmails.map((email, index) => (
-            <div key={index} className="flex gap-2">
+            <div key={index} className="flex items-center gap-2">
               <Input
                 type="email"
                 placeholder="teammate@company.com"
@@ -94,7 +94,7 @@ export default function OrganizationSetupForm({ onSubmit }: OrganizationSetupFor
                   variant="outline"
                   size="icon"
                   onClick={() => removeEmailField(index)}
-                  className="shrink-0"
+                  className="shrink-0 h-9 w-9 flex items-center justify-center"
                 >
                   <X className="h-4 w-4" />
                 </Button>


### PR DESCRIPTION
## Fix Email Remove Button Alignment in Organization Setup

### Part of: #411 

## Problem
The remove (X) button for team member email fields was not vertically centered with the input fields in the organization setup form, creating a misaligned UI.

##  Solution
Applied proper Flexbox alignment and sizing to ensure buttons are perfectly centered with their corresponding input fields.


### Before
<img width="529" height="719" alt="Screenshot 2025-09-11 at 12 41 16 AM" src="https://github.com/user-attachments/assets/a6f1b81a-9a69-41dc-a945-9dba329323b0" />

### After
<img width="544" height="740" alt="Screenshot 2025-09-11 at 12 41 44 AM" src="https://github.com/user-attachments/assets/42965af9-a597-4e3a-a891-a38f3182138a" />

### AI disclosure 
NO AI used.