### PR TITLE
fix: Prevent text overflow in board settings modal

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1022,7 +1022,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             <AlertDialogTitle className="text-foreground dark:text-zinc-100">
               Board settings
             </AlertDialogTitle>
-            <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400 break-all">
+            <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400 [overflow-wrap:anywhere]">
               Configure settings for &quot;{board?.name}&quot; board.
             </AlertDialogDescription>
           </AlertDialogHeader>


### PR DESCRIPTION
## Fix board settings modal text overflow

### Part of: #411 

### Before
Long board names caused horizontal scrolling in the modal, making it unusable on mobile.

### After  
Board names now wrap properly within the modal container using `break-all` class.

### Changes
- Added `break-all` to `AlertDialogDescription` in board settings modal

### Before
<img width="1439" height="899" alt="Screenshot 2025-09-11 at 2 01 38 AM" src="https://github.com/user-attachments/assets/125ff307-cca4-417e-9a87-8c34dbe71330" />
<img width="369" height="809" alt="Screenshot 2025-09-11 at 2 31 30 AM" src="https://github.com/user-attachments/assets/0756bf29-fcf7-4fdf-baf1-f6ab301bfbf2" />


### After
<img width="541" height="542" alt="Screenshot 2025-09-11 at 10 39 36 PM" src="https://github.com/user-attachments/assets/1bfd6eed-91d1-4785-9050-0fcf6156cebb" />

<img width="369" height="807" alt="Screenshot 2025-09-11 at 10 40 03 PM" src="https://github.com/user-attachments/assets/2edd8b6d-38da-4121-ad76-4728b98d9d12" />


### AI disclosure 
No AI used
