### PR TITLE
fix(ui): handling text overflow on boards

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -709,21 +709,21 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               </PopoverTrigger>
 
               <PopoverContent
-                className="p-2 w-full sm:w-64 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
+                className="p-2 max-w-screen md:max-w-72 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800 overflow-x-hidden"
                 align="start"
               >
                 <div className="flex flex-col gap-1">
-                  <div className="max-h-50 overflow-y-auto">
+                  <div className="max-h-50 overflow-y-auto overflow-x-hidden">
                     {allBoards.map((b) => (
                       <Link
                         key={b.id}
                         href={`/boards/${b.id}`}
                         data-board-id={b.id}
-                        className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-white ${
+                        className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-white truncate ${
                           b.id === boardId
                             ? "bg-sky-50 dark:bg-sky-600 text-foreground dark:text-zinc-100 font-semibold"
                             : "text-foreground dark:text-zinc-100"
-                        }`}
+                        } turncate whitespace-nowrap`}
                       >
                         <div data-board-name={b.name}>{b.name}</div>
                       </Link>

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -352,7 +352,7 @@ export function Note({
       style={style}
     >
       <div className="flex items-start justify-between mb-2 flex-shrink-0">
-        <div className="flex items-center space-x-2">
+        <div className="flex-1 min-w-0 flex items-center space-x-2">
           <Avatar className="h-7 w-7">
             <AvatarFallback className="bg-white/50 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 text-sm font-semibold">
               {note.user.name
@@ -366,7 +366,7 @@ export function Note({
             />
           </Avatar>
           <div className="flex flex-col">
-            <span className="text-sm font-bold text-gray-700 dark:text-zinc-100 max-w-20">
+            <span className="text-sm font-bold text-gray-700 dark:text-zinc-100 max-w-40 overflow-x-hidden truncate">
               {note.user.name ? note.user.name.split(" ")[0] : note.user.email.split("@")[0]}
             </span>
             <div className="flex flex-col">

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -24,7 +24,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-white dark:bg-zinc-900 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) border border-zinc-100 dark:border-zinc-800 rounded-md p-4 shadow-md outline-hidden",
+          "bg-white dark:bg-zinc-900 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-(--radix-popover-content-transform-origin) border border-zinc-100 dark:border-zinc-800 rounded-md p-4 shadow-md outline-hidden",
           className
         )}
         {...props}


### PR DESCRIPTION
ref #411 

# Summary:

- fixed multiple scenario of text overflow when given a long name to the board and organizations

Before :
<img width="1063" height="220" alt="Screenshot 2025-09-11 at 7 15 19 AM" src="https://github.com/user-attachments/assets/ae58a247-e2ae-490a-a8d7-0c915d088b80" />

After : 
 

https://github.com/user-attachments/assets/387b1935-01e6-408f-80c1-ae9cc5236c37


Before :
<img width="349" height="395" alt="Screenshot 2025-09-11 at 7 15 37 AM" src="https://github.com/user-attachments/assets/1e1c6e96-b603-49cc-8321-7957a0a30fef" />

After :
<img width="359" height="401" alt="Screenshot 2025-09-11 at 7 18 04 AM" src="https://github.com/user-attachments/assets/2b035723-7f8e-4a53-bea4-9384ca6bdc3d" />

Before :

https://github.com/user-attachments/assets/f0b52d43-7790-459b-aaea-66da089d8a32

After :

https://github.com/user-attachments/assets/4200f8b6-b77e-4b00-aa55-ccceb1ee2387

Before :

https://github.com/user-attachments/assets/5548e2f6-8bd6-430a-9f4b-7f8b59649ce4

After :

https://github.com/user-attachments/assets/3eb05a9c-7ac6-4b40-9119-da3a19cb5c60




## AI USAGE:
No AI was used to generate any of this code.

## Self Review:
I have self reviewed all the code that i have written 