### PR TITLE
feat: improve public/private visibility of a board on board pages

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -712,11 +712,12 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               </PopoverTrigger>
 
               <PopoverContent
-                className="p-2 w-full sm:w-64 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
+                className="p-2 mt-2 w-[calc(100vw-1.75rem)] sm:w-80 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
                 align="start"
+                alignOffset={-10}
               >
                 <div className="flex flex-col gap-1">
-                  <div className="max-h-50 overflow-y-auto">
+                  <div className="max-h-[50dvh] overflow-y-auto">
                     {allBoards.map((b) => (
                       <Link
                         key={b.id}

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -6,7 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { ChevronDown, Search, Copy, Trash2, X, EllipsisVertical } from "lucide-react";
+import {
+  Archive,
+  ChevronDown,
+  Grid3x3,
+  Search,
+  Copy,
+  Trash2,
+  X,
+  EllipsisVertical,
+  Globe,
+  LockKeyhole,
+} from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { FilterPopover } from "@/components/ui/filter-popover";
@@ -243,6 +254,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           id: "all-notes",
           name: "All notes",
           description: "Notes from all boards",
+          isPublic: false,
         });
       } else if (boardId === "archive") {
         [allBoardsResponse, notesResponse] = await Promise.all([
@@ -255,6 +267,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           id: "archive",
           name: "Archive",
           description: "Archived notes from all boards",
+          isPublic: false,
         });
       } else {
         [allBoardsResponse, boardResponse, notesResponse] = await Promise.all([
@@ -697,12 +710,28 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 className="board-dropdown mr-0 min-w-32 sm:max-w-64 col-span-2 sm:col-span-1"
               >
                 <Button variant="ghost" className="flex items-center justify-between p-2 w-full">
-                  <div className="text-sm font-semibold text-foreground dark:text-zinc-100 truncate">
-                    {boardId === "all-notes"
-                      ? "All notes"
-                      : boardId === "archive"
-                        ? "Archive"
-                        : board?.name}
+                  
+                  <div
+                    className="grid grid-cols-[auto_1rem] items-center gap-2 flex-1"
+                  >
+                    <span className="text-sm text-left font-semibold text-foreground dark:text-zinc-100 truncate">
+                      {boardId === "all-notes"
+                        ? "All notes"
+                        : boardId === "archive"
+                          ? "Archive"
+                          : board?.name}
+                    </span>
+                    <span>
+                      {boardId === "all-notes"
+                        ? <Grid3x3 className="size-4 text-muted-foreground" />
+                        : boardId === "archive"
+                          ? <Archive className="size-4 text-muted-foreground" />
+                          : board?.isPublic ? (
+                        <Globe className="size-4 text-muted-foreground" />
+                      ) : (
+                        <LockKeyhole className="size-4 text-muted-foreground" />
+                      )}
+                    </span>
                   </div>
                   <ChevronDown
                     size={16}
@@ -729,7 +758,17 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                             : "text-foreground dark:text-zinc-100"
                         }`}
                       >
-                        <div data-board-name={b.name}>{b.name}</div>
+                        <div
+                          data-board-name={b.name}
+                          className="grid grid-cols-[auto_1rem] items-center gap-2"
+                        >
+                          {b.name}
+                          {b.isPublic ? (
+                            <Globe className="size-4 text-muted-foreground" />
+                          ) : (
+                            <LockKeyhole className="size-4 text-muted-foreground" />
+                          )}
+                        </div>
                       </Link>
                     ))}
                   </div>
@@ -741,25 +780,27 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   {/* All Notes Option */}
                   <Link
                     href="/boards/all-notes"
-                    className={`rounded-lg font-medium block px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                    className={`rounded-lg font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 grid grid-cols-[auto_1rem] items-center gap-2 ${
                       boardId === "all-notes"
                         ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
                         : "text-foreground dark:text-white"
                     }`}
                   >
                     <div>All notes</div>
+                    <Grid3x3 className="size-4 text-muted-foreground" />
                   </Link>
 
                   {/* Archive Option */}
                   <Link
                     href="/boards/archive"
-                    className={`rounded-lg block font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                    className={`rounded-lg font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 grid grid-cols-[auto_1rem] items-center gap-2 ${
                       boardId === "archive"
                         ? "bg-zinc-100 dark:bg-zinc-800 dark:text-white font-semibold"
                         : "text-foreground dark:text-white"
                     }`}
                   >
                     <div>All archived</div>
+                    <Archive className="size-4 text-muted-foreground" />
                   </Link>
                   <div className="border-t border-zinc-100 dark:border-zinc-800 my-1"></div>
                   <Button

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -710,10 +710,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 className="board-dropdown mr-0 min-w-32 sm:max-w-64 col-span-2 sm:col-span-1"
               >
                 <Button variant="ghost" className="flex items-center justify-between p-2 w-full">
-                  
-                  <div
-                    className="grid grid-cols-[auto_1rem] items-center gap-2 flex-1"
-                  >
+                  <div className="grid grid-cols-[auto_1rem] items-center gap-2 flex-1">
                     <span className="text-sm text-left font-semibold text-foreground dark:text-zinc-100 truncate">
                       {boardId === "all-notes"
                         ? "All notes"
@@ -722,11 +719,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                           : board?.name}
                     </span>
                     <span>
-                      {boardId === "all-notes"
-                        ? <Grid3x3 className="size-4 text-muted-foreground" />
-                        : boardId === "archive"
-                          ? <Archive className="size-4 text-muted-foreground" />
-                          : board?.isPublic ? (
+                      {boardId === "all-notes" ? (
+                        <Grid3x3 className="size-4 text-muted-foreground" />
+                      ) : boardId === "archive" ? (
+                        <Archive className="size-4 text-muted-foreground" />
+                      ) : board?.isPublic ? (
                         <Globe className="size-4 text-muted-foreground" />
                       ) : (
                         <LockKeyhole className="size-4 text-muted-foreground" />

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -28,6 +28,7 @@ export interface Board {
   id: string;
   name: string;
   description: string | null;
+  isPublic: boolean;
 }
 
 export interface Note {

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -237,7 +237,7 @@ test.describe("Board Management", () => {
 
       await authenticatedPage.locator("[data-testid='board-dropdown-trigger']").click();
 
-      await authenticatedPage.getByText("All notes").click();
+      await authenticatedPage.getByRole("link", { name: "All notes" }).click();
       await expect(authenticatedPage).toHaveURL("/boards/all-notes");
     });
 
@@ -259,7 +259,7 @@ test.describe("Board Management", () => {
 
       await authenticatedPage.locator("[data-testid='board-dropdown-trigger']").click();
 
-      await authenticatedPage.getByText("All archived").click();
+      await authenticatedPage.getByRole("link", { name: "All archived" }).click();
       await expect(authenticatedPage).toHaveURL("/boards/archive");
     });
   });

--- a/tests/e2e/dashboard/board-card.spec.ts
+++ b/tests/e2e/dashboard/board-card.spec.ts
@@ -73,7 +73,6 @@ test.describe("Board Card", () => {
     await expect(newBoardCard).toBeVisible();
 
     // go to card header then search for span that contain notes count
-    const noteCount = newBoardCard.locator("span");
-    await expect(noteCount).toHaveText(/^\d+ note(s)?$/);
+    await expect(newBoardCard.locator("span").filter({ hasText: /^\d+ notes?$/ })).toBeVisible();
   });
 });


### PR DESCRIPTION
This PR enhances the board selector UI by adding dedicated icons for different types of boards in the board selector.

### Changes
1. `Public` boards now display a globe icon besides them
2. `Private` boards now display a lock-closed icon
3. `All Notes` and `Archive` boards re-use their icon from dashboard listing 

### After

https://github.com/user-attachments/assets/99e391ec-1c2d-4e7c-aa6d-3ae4f59d954f

https://github.com/user-attachments/assets/5b7fac5a-06a3-4a2a-868d-1dc0aa852199


- Ref #411
- To be merged after #730 or directly merge this for both the changes

### AI Usage:
None