### PR TITLE
suppress Auth.js [auth][error] (not needed) logs during e2e runs

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -6,6 +6,8 @@ import GitHubProvider from "next-auth/providers/github";
 import { db as prisma } from "@/lib/db";
 import { env } from "@/lib/env";
 
+const isE2E = process.env.E2E === "1" || process.env.NODE_ENV === "test";
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -23,6 +25,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       allowDangerousEmailAccountLinking: true,
     }),
   ],
+  logger: isE2E
+    ? {
+        error: () => {},
+        warn: () => {},
+        debug: () => {},
+      }
+    : undefined,
   pages: {
     signIn: "/auth/signin",
     verifyRequest: "/auth/verify-request",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:e2e": "E2E=1 playwright test",
+    "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:e2e": "playwright test",
+    "test:e2e": "E2E=1 playwright test",
     "test:e2e:ui": "playwright test --ui",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,5 +23,10 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      E2E: '1',
+    },
   },
 });


### PR DESCRIPTION
#411 
This change reduces noise in E2E test output by disabling (only while e2e tests) unnecessary `[auth][error]` logs from Auth.js.

### Why

OAuth callbacks can fail during tests and produce irrelevant error logs. These logs make it harder to identify real test failures.


### Before

<img width="1175" height="1007" alt="Before" src="https://github.com/user-attachments/assets/d4b79fc8-5ace-495e-90cf-ffb87ebca93d" />


### After

<img width="694" height="245" alt="After" src="https://github.com/user-attachments/assets/50e0ca16-80e6-4452-a231-f645d9511a3d" />


### What’s changed

* Suppresses `[auth][error]` logs during E2E runs.
* Adds a conditional no-op Auth.js logger when either:

  * `NODE_ENV=test`, or
  * `E2E=1` is set.
* Updates `playwright.config.ts`:

  * Sets `webServer.env` to include `NODE_ENV=test` and `E2E=1` when starting the Next.js server.


