### PR TITLE
fix: add error handling to joinOrganization server action to prevent runtime crashes

### DIFF
--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -11,7 +11,7 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 async function joinOrganization(token: string) {
   "use server";
 
-  try{
+  try {
     const session = await auth();
     if (!session?.user?.id || !session?.user?.email) {
       throw new Error("Not authenticated");
@@ -71,15 +71,12 @@ async function joinOrganization(token: string) {
 
     console.log("Redirecting to dashboard");
     redirect("/dashboard");
-  }
-  catch(error){
+  } catch (error) {
     // Re-throw NEXT_REDIRECT errors as they are handled by Next.js
     if (isRedirectError(error)) {
       throw error;
     }
-    redirect(
-      `/join/${token}`
-    );   
+    redirect(`/join/${token}`);
   }
 }
 
@@ -171,8 +168,8 @@ async function autoCreateAccountAndJoin(token: string, formData: FormData) {
       `/api/auth/set-session?token=${sessionToken}&redirectTo=${encodeURIComponent("/dashboard")}`
     );
   } catch (error) {
-    if(isRedirectError(error)){
-      throw error
+    if (isRedirectError(error)) {
+      throw error;
     }
     console.error("Auto-join error:", error);
     // Fallback to regular auth flow

--- a/tests/e2e/join-organization.spec.ts
+++ b/tests/e2e/join-organization.spec.ts
@@ -4,10 +4,16 @@ test.describe("Join Organization", () => {
   test("should show invalid invitation error for non-existent token", async ({ page }) => {
     await page.goto("/join/non-existent-token");
     await expect(page.locator("text=Invalid Invitation")).toBeVisible();
-    await expect(page.locator("text=This invitation link is invalid or has expired.")).toBeVisible();
+    await expect(
+      page.locator("text=This invitation link is invalid or has expired.")
+    ).toBeVisible();
   });
 
-  test("should show expired invitation error", async ({ authenticatedPage, testContext, testPrisma }) => {
+  test("should show expired invitation error", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
     const expiredInvite = await testPrisma.organizationSelfServeInvite.create({
       data: {
         name: `Expired Invite ${testContext.testId}`,
@@ -41,10 +47,16 @@ test.describe("Join Organization", () => {
     await page.goto(`/join/${limitReachedInvite.token}`);
 
     await expect(page.locator("text=Invitation Limit Reached")).toBeVisible();
-    await expect(page.locator("text=This invitation has reached its maximum usage limit of 2 uses.")).toBeVisible();
+    await expect(
+      page.locator("text=This invitation has reached its maximum usage limit of 2 uses.")
+    ).toBeVisible();
   });
 
-  test("should show join form for unauthenticated users", async ({ page, testContext, testPrisma }) => {
+  test("should show join form for unauthenticated users", async ({
+    page,
+    testContext,
+    testPrisma,
+  }) => {
     const validInvite = await testPrisma.organizationSelfServeInvite.create({
       data: {
         name: `Valid Invite ${testContext.testId}`,
@@ -128,7 +140,7 @@ test.describe("Join Organization", () => {
     await page.goto(`/join/${validInvite.token}`);
 
     // Should show join confirmation (since user is authenticated but not in the target org)
-    await expect(page.locator(`text=Join ${org.name} on Gumboard!`)).toBeVisible();  
+    await expect(page.locator(`text=Join ${org.name} on Gumboard!`)).toBeVisible();
     await expect(page.locator('button[type="submit"]')).toBeVisible();
   });
 
@@ -179,7 +191,7 @@ test.describe("Join Organization", () => {
     // Set the session cookie
     await page.context().addCookies([
       {
-        name: "authjs.session-token",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+        name: "authjs.session-token",
         value: sessionToken,
         domain: "localhost",
         path: "/",
@@ -195,4 +207,4 @@ test.describe("Join Organization", () => {
     await expect(page.locator("text=Already in Organization")).toBeVisible();
     await expect(page.locator(`text=You are already a member of ${otherOrg.name}`)).toBeVisible();
   });
-})
+});

--- a/tests/e2e/join-organization.spec.ts
+++ b/tests/e2e/join-organization.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Join Organization", () => {
+  test("should show invalid invitation error for non-existent token", async ({ page }) => {
+    await page.goto("/join/non-existent-token");
+    await expect(page.locator("text=Invalid Invitation")).toBeVisible();
+    await expect(page.locator("text=This invitation link is invalid or has expired.")).toBeVisible();
+  });
+
+  test("should show expired invitation error", async ({ authenticatedPage, testContext, testPrisma }) => {
+    const expiredInvite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: `Expired Invite ${testContext.testId}`,
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+        usageLimit: 5,
+        usageCount: 0,
+        token: `expired_token_${testContext.testId}`,
+        expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // Expired 1 day ago
+      },
+    });
+
+    await authenticatedPage.goto(`/join/${expiredInvite.token}`);
+    await expect(authenticatedPage.locator("text=This invitation expired on")).toBeVisible();
+  });
+
+  test("should show usage limit reached error", async ({ page, testContext, testPrisma }) => {
+    const limitReachedInvite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: `Limit Reached Invite ${testContext.testId}`,
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+        usageLimit: 2,
+        usageCount: 2, // Limit reached
+        token: `limit_reached_token_${testContext.testId}`,
+      },
+    });
+
+    await page.goto(`/join/${limitReachedInvite.token}`);
+
+    await expect(page.locator("text=Invitation Limit Reached")).toBeVisible();
+    await expect(page.locator("text=This invitation has reached its maximum usage limit of 2 uses.")).toBeVisible();
+  });
+
+  test("should show join form for unauthenticated users", async ({ page, testContext, testPrisma }) => {
+    const validInvite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: `Valid Invite ${testContext.testId}`,
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+        usageLimit: 5,
+        usageCount: 0,
+        token: `valid_token_${testContext.testId}`,
+      },
+    });
+
+    // Get organization name for the test
+    const organization = await testPrisma.organization.findUnique({
+      where: { id: testContext.organizationId },
+    });
+
+    await page.goto(`/join/${validInvite.token}`);
+
+    // Should show the join form
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.locator("text=Already have an account?")).toBeVisible();
+  });
+
+  test("should show join confirmation for authenticated users not in organization", async ({
+    page,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create a different organization for the invite
+    const org = await testPrisma.organization.create({
+      data: {
+        id: `new_org_${testContext.testId}`,
+        name: `Org ${testContext.testId}`,
+      },
+    });
+
+    const user = await testPrisma.user.create({
+      data: {
+        id: `user_${testContext.testId}`,
+        email: `user_${testContext.testId}@example.com`,
+      },
+    });
+
+    // Create session for this user
+    const sessionToken = `session_${testContext.testId}`;
+    await testPrisma.session.create({
+      data: {
+        sessionToken,
+        userId: user.id,
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const validInvite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: `Org Invite ${testContext.testId}`,
+        organizationId: org.id,
+        createdBy: testContext.userId,
+        isActive: true,
+        usageLimit: 5,
+        usageCount: 0,
+        token: `org_token_${testContext.testId}`,
+      },
+    });
+
+    // Set the session cookie
+    await page.context().addCookies([
+      {
+        name: "authjs.session-token",
+        value: sessionToken,
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        secure: false,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await page.goto(`/join/${validInvite.token}`);
+
+    // Should show join confirmation (since user is authenticated but not in the target org)
+    await expect(page.locator(`text=Join ${org.name} on Gumboard!`)).toBeVisible();  
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
+  });
+
+  test("should show already in organization error for authenticated users", async ({
+    page,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create user in a different organization
+    const otherOrg = await testPrisma.organization.create({
+      data: {
+        id: `other_org_${testContext.testId}`,
+        name: `Other Org ${testContext.testId}`,
+      },
+    });
+
+    const user = await testPrisma.user.create({
+      data: {
+        id: `user_in_other_org_${testContext.testId}`,
+        email: `user_in_other_org_${testContext.testId}@example.com`,
+        organizationId: otherOrg.id,
+      },
+    });
+
+    // Create session for this user
+    const sessionToken = `session_${testContext.testId}_other_org`;
+    await testPrisma.session.create({
+      data: {
+        sessionToken,
+        userId: user.id,
+        expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    // Create invite for the test organization (different from user's org)
+    const validInvite = await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        name: `Test Org Invite ${testContext.testId}`,
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+        isActive: true,
+        usageLimit: 5,
+        usageCount: 0,
+        token: `test_org_token_${testContext.testId}`,
+      },
+    });
+
+    // Set the session cookie
+    await page.context().addCookies([
+      {
+        name: "authjs.session-token",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+        value: sessionToken,
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        secure: false,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await page.goto(`/join/${validInvite.token}`);
+
+    // Should show already in organization error
+    await expect(page.locator("text=Already in Organization")).toBeVisible();
+    await expect(page.locator(`text=You are already a member of ${otherOrg.name}`)).toBeVisible();
+  });
+})


### PR DESCRIPTION
Under #411 
Previously, the joinOrganization server action did not have a try/catch block.
As a result, any unhandled error (e.g., invalid invite, expired token, or missing session) would bubble up to Next.js and cause a runtime error on the frontend.

Before:

https://github.com/user-attachments/assets/c9992c25-2ec1-4975-a462-f785c3217b86

After:

https://github.com/user-attachments/assets/205fc7c6-7015-439c-afa0-bd9446f45a37

### Changes made

- Added a try catch block to the server action
- Added e2e tests

### Test
<img width="760" height="148" alt="image" src="https://github.com/user-attachments/assets/746002ea-6127-4fa8-965e-c66cda6d1a6a" />
 