### PR TITLE
Delete button misaligned outside member box when member name is long

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -633,7 +633,7 @@ export default function OrganizationSettingsPage() {
                     <p className="text-sm text-zinc-600 dark:text-zinc-400">{member.email}</p>
                   </div>
                 </div>
-                <div className="flex items-center space-x-2">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   {/* Only show admin toggle to current admins and not for yourself */}
                   {user?.isAdmin && member.id !== user.id && (
                     <Button


### PR DESCRIPTION
That class makes the container stack vertically on mobile and align horizontally on larger screens

Before:


https://github.com/user-attachments/assets/21d100ca-631d-4cb3-957c-a168a1496c41


After:


https://github.com/user-attachments/assets/2c51feb7-e1fe-41ee-87bb-9baeab0f8c20

