### PR TITLE
fix(ui): handling flex container when note is empty

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -861,23 +861,22 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               </div>
             )}
 
-        <div className="flex gap-2">
-            <Button
-              onClick={() => {
-                if (boardId === "all-notes" && allBoards.length > 0) {
-                  handleAddNote(allBoards[0].id);
-                } else {
-                  handleAddNote();
-                }
-              }}
-              disabled={boardId === "archive"}
-              className="col-span-2 md:col-span-1 flex-1"
-            >
-              <span>Add note</span>
-            </Button>
-            {notes.length==0 &&<ProfileDropdown user={user} />}
-        </div>
-
+            <div className="flex gap-2">
+              <Button
+                onClick={() => {
+                  if (boardId === "all-notes" && allBoards.length > 0) {
+                    handleAddNote(allBoards[0].id);
+                  } else {
+                    handleAddNote();
+                  }
+                }}
+                disabled={boardId === "archive"}
+                className="col-span-2 md:col-span-1 flex-1"
+              >
+                <span>Add note</span>
+              </Button>
+              {notes.length == 0 && <ProfileDropdown user={user} />}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
ref #411 

## Description
- Fixed the issue where profile icon is shown below `Add Notes` button when all notes are `empty`

Before:
<img width="364" height="758" alt="Screenshot 2025-09-11 at 9 03 38 PM" src="https://github.com/user-attachments/assets/116fd9ef-8f5f-4c9c-8cc8-2ac8cc511e51" />


After :
<img width="374" height="754" alt="Screenshot 2025-09-11 at 9 39 57 PM" src="https://github.com/user-attachments/assets/3ba7cee9-998d-45df-a540-1d4d6262c9ac" />



## AI disclosure
No AI usage

## Self Review
Have done self review from my side 
