### PR TITLE
fix: hide previous days in the calendar at invite links

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -822,6 +822,7 @@ export default function OrganizationSettingsPage() {
                       }}
                       autoFocus
                       showOutsideDays={true}
+                      disabled={{ before: new Date() }}
                       classNames={{
                         weekday:
                           "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",


### PR DESCRIPTION
ref: #411 


### Description
- hides the previous dates at date picker ( calendar ) for self serve invite links.



### Before:
<img width="377" height="393" alt="Screenshot from 2025-09-11 22-17-53" src="https://github.com/user-attachments/assets/a61c4c42-13e9-4911-ba8c-d3b64b45bcc9" />


### After: 

<img width="377" height="393" alt="image" src="https://github.com/user-attachments/assets/6e790363-f247-4f15-9bd3-2dc74ebfdd36" />

### tests

only styling changes.