### PR TITLE
fix: Prevent text overflow in empty state message.

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -920,7 +920,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               {boardId === "archive" ? "No archived notes" : "No notes yet"}
             </h3>
 
-            <p className="text-muted-foreground dark:text-zinc-400 mb-6 max-w-md">
+            <p className="text-muted-foreground dark:text-zinc-400 mb-6 max-w-md [overflow-wrap:anywhere]">
               {boardId === "archive"
                 ? "Notes that you archive will appear here. Archived notes are hidden from your active boards but can be restored anytime."
                 : board?.name


### PR DESCRIPTION
##  Bug Fix: Text Overflow in Empty State

### Part of: #411 

### Problem
Long board names were causing text overflow in the "No notes yet" empty state message across all screen sizes, making the text extend beyond the container boundaries and creating a poor user experience.

### Solution
Added Tailwind's arbitrary value `[overflow-wrap:anywhere]` to the empty state paragraph element.

### Changes
- **File**: `app/boards/[id]/page.tsx`
- **Change**: Added `[overflow-wrap:anywhere]` class to the empty state message paragraph

### Before vs After
- **Before**: 
**Desktop**
<img width="1438" height="896" alt="Screenshot 2025-09-11 at 10 07 25 PM" src="https://github.com/user-attachments/assets/00d16bfb-03ff-4e89-b01a-2dd571005b42" />

**Mobile**
<img width="371" height="671" alt="Screenshot 2025-09-11 at 10 07 35 PM" src="https://github.com/user-attachments/assets/94771b39-f9a4-459f-ba85-d36e2eb9dd17" />

- **After**
**Desktop**
<img width="1440" height="900" alt="Screenshot 2025-09-11 at 10 27 12 PM" src="https://github.com/user-attachments/assets/b72b78f3-7ad8-4d4b-897f-34d5c18a7b51" />

**Mobile**
<img width="370" height="812" alt="Screenshot 2025-09-11 at 10 27 48 PM" src="https://github.com/user-attachments/assets/81aba176-3674-430f-8543-f7ce45ecf9a7" />

### Testing
<img width="1018" height="189" alt="Screenshot 2025-09-11 at 10 30 38 PM" src="https://github.com/user-attachments/assets/9c15de9f-2e4d-4704-a4d1-4949ead1e3a2" />
