### PR TITLE
fix: replace Input with textarea

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -246,13 +246,13 @@ export default function Dashboard() {
                     <FormItem>
                       <FormLabel>Description (Optional)</FormLabel>
                       <FormControl>
-                         <textarea
-                        placeholder="Enter board description"
-                        className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 
+                        <textarea
+                          placeholder="Enter board description"
+                          className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 
                         w-full min-h-[60px] text-base md:text-sm rounded-md px-3 py-2 outline-none 
                         focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500 focus:border-blue-500"
-                        {...field}
-                      />
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -246,11 +246,13 @@ export default function Dashboard() {
                     <FormItem>
                       <FormLabel>Description (Optional)</FormLabel>
                       <FormControl>
-                        <Input
-                          placeholder="Enter board description"
-                          className="border border-zinc-200 dark:border-zinc-800 text-muted-foreground dark:text-zinc-200"
-                          {...field}
-                        />
+                         <textarea
+                        placeholder="Enter board description"
+                        className="bg-white dark:bg-zinc-900 text-foreground dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 
+                        w-full min-h-[60px] text-base md:text-sm rounded-md px-3 py-2 outline-none 
+                        focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500 focus:border-blue-500"
+                        {...field}
+                      />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -12,7 +12,7 @@ test.describe("Board Management", () => {
 
     await authenticatedPage.click('button:has-text("Add Board")');
     await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
-    await authenticatedPage.fill('input[placeholder*="board description"]', boardDescription);
+    await authenticatedPage.fill('textarea[placeholder*="board description"]', boardDescription);
     const responsePromise = authenticatedPage.waitForResponse(
       (resp) => resp.url().includes("/api/boards") && resp.status() === 201
     );


### PR DESCRIPTION
ref: #411 


### Description
- replace ` <Input/> ` with textarea for description at dashboard - create new board.



### Before:
<img width="468" height="417" alt="image" src="https://github.com/user-attachments/assets/77941d70-fd3a-4fad-8d78-2bf287819457" />


### After: 
<img width="468" height="417" alt="image" src="https://github.com/user-attachments/assets/4f4aadfb-ecff-43b0-9321-a7ced83e3351" />

### Tests
<img width="964" height="675" alt="image" src="https://github.com/user-attachments/assets/cc26c898-dfdb-4b64-9d4e-58c3ddb2509b" />

