### PR TITLE
fix(ui): overflow at `join` page

### DIFF
--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -238,7 +238,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-zinc-950 p-4">
         <div className="w-full max-w-md space-y-8">
-          <div className="text-center space-y-3 break-all">
+          <div className="text-center space-y-3 [overflow-wrap:anywhere] ">
             <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
               Join {invite.organization.name} on Gumboard!
             </h1>
@@ -257,7 +257,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
                   {invite.organization.name.charAt(0).toUpperCase()}
                 </span>
               </div>
-              <CardTitle className="text-2xl font-semibold text-slate-900 dark:text-slate-100 -mt-5 break-all">
+              <CardTitle className="text-2xl font-semibold text-slate-900 dark:text-slate-100 -mt-5  [overflow-wrap:anywhere]">
                 {invite.organization.name}
               </CardTitle>
             </CardHeader>

--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -296,7 +296,10 @@ export default async function JoinPage({ params }: JoinPageProps) {
                     placeholder="Enter your email address"
                   />
                 </div>
-                <Button type="submit" className="w-full px-4 py-5 truncate break-all text-ellipsis whitespace-nowrap overflow-hidden text-ellipsis ">
+                <Button
+                  type="submit"
+                  className="w-full px-4 py-5 truncate break-all text-ellipsis whitespace-nowrap overflow-hidden text-ellipsis "
+                >
                   Join {invite.organization.name}
                 </Button>
               </form>

--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -238,7 +238,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-zinc-950 p-4">
         <div className="w-full max-w-md space-y-8">
-          <div className="text-center space-y-3">
+          <div className="text-center space-y-3 break-all">
             <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
               Join {invite.organization.name} on Gumboard!
             </h1>
@@ -257,7 +257,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
                   {invite.organization.name.charAt(0).toUpperCase()}
                 </span>
               </div>
-              <CardTitle className="text-2xl font-semibold text-slate-900 dark:text-slate-100 -mt-5">
+              <CardTitle className="text-2xl font-semibold text-slate-900 dark:text-slate-100 -mt-5 break-all">
                 {invite.organization.name}
               </CardTitle>
             </CardHeader>
@@ -296,7 +296,7 @@ export default async function JoinPage({ params }: JoinPageProps) {
                     placeholder="Enter your email address"
                   />
                 </div>
-                <Button type="submit" className="w-full px-4 py-5">
+                <Button type="submit" className="w-full px-4 py-5 truncate break-all text-ellipsis whitespace-nowrap overflow-hidden text-ellipsis ">
                   Join {invite.organization.name}
                 </Button>
               </form>


### PR DESCRIPTION
ref #411 

## Description
- Fixes overflow in `/join` page 

Before:
<img width="1854" height="959" alt="Screenshot 2025-09-11 at 11 00 45 PM" src="https://github.com/user-attachments/assets/b9a6ab60-298f-44e4-856a-c3bf3a174f10" />



After :
<img width="1865" height="959" alt="Screenshot 2025-09-11 at 11 01 26 PM" src="https://github.com/user-attachments/assets/fd5f71a9-b983-40c6-8454-1b29ca77f9c4" />


Before:
<img width="372" height="757" alt="Screenshot 2025-09-11 at 11 00 58 PM" src="https://github.com/user-attachments/assets/1fe95ec5-b29e-45cb-a496-6d8044211628" />




After :
<img width="354" height="750" alt="Screenshot 2025-09-11 at 11 01 17 PM" src="https://github.com/user-attachments/assets/9f1070d5-25a1-4c05-be21-3e4fab17bf76" />



## AI disclosure
No AI usage

## Self Review
Have done self review from my side 
