### PR TITLE
feat: Add Plus icon to Add note button for consistent UI

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -869,8 +869,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 }
               }}
               disabled={boardId === "archive"}
-              className="col-span-2 md:col-span-1"
+              className="col-span-2 md:col-span-1 flex items-center"
             >
+              <Plus className="w-4 h-4" />
               <span>Add note</span>
             </Button>
 


### PR DESCRIPTION
##  Feature: Add Plus Icon to "Add note" Button

### Part of: #411 

### Overview
Adds a Plus icon to the "Add note" button to match the visual consistency of the "Add Board" button across the application.

### Changes
  - Updated button layout with `flex items-center` for proper icon-text alignment
  - Maintains existing functionality while improving visual consistency

### Before vs After
- **Before**
<img width="1440" height="68" alt="Screenshot 2025-09-12 at 12 11 37 AM" src="https://github.com/user-attachments/assets/c2bfb0b8-4b4b-4657-bd8a-6298ebbf52b4" />

- **After**
<img width="1440" height="67" alt="Screenshot 2025-09-12 at 12 11 21 AM" src="https://github.com/user-attachments/assets/b7fd5705-3cf8-4100-9fb6-ef102aaedf65" />

### Design Consistency
This change ensures that both primary action buttons follow the same visual pattern:

