### PR TITLE
fix: hide add note button at archive board

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -862,20 +862,21 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 )}
               </div>
             )}
-            <Button
-              onClick={() => {
-                if (boardId === "all-notes" && allBoards.length > 0) {
-                  handleAddNote(allBoards[0].id);
-                } else {
-                  handleAddNote();
-                }
-              }}
-              disabled={boardId === "archive"}
-              className="col-span-2 md:col-span-1 flex items-center"
-            >
-              <Plus className="w-4 h-4" />
-              <span>Add note</span>
-            </Button>
+           {boardId !== "archive" ? (
+              <Button
+                onClick={() => {
+                  if (allBoards.length > 0) {
+                    handleAddNote(allBoards[0].id);
+                  } else {
+                    handleAddNote();
+                  }
+                }}
+                className="col-span-2 md:col-span-1 flex items-center"
+              >
+               <Plus className="w-4 h-4" />
+                <span>Add note</span>
+              </Button>
+            ) : null}
 
             {/* User Dropdown */}
             <ProfileDropdown user={user} />

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -862,7 +862,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 )}
               </div>
             )}
-           {boardId !== "archive" ? (
+            {boardId !== "archive" ? (
               <Button
                 onClick={() => {
                   if (allBoards.length > 0) {
@@ -873,7 +873,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 }}
                 className="col-span-2 md:col-span-1 flex items-center"
               >
-               <Plus className="w-4 h-4" />
+                <Plus className="w-4 h-4" />
                 <span>Add note</span>
               </Button>
             ) : null}

--- a/components/board-skeleton.tsx
+++ b/components/board-skeleton.tsx
@@ -1,7 +1,9 @@
+import { usePathname } from "next/navigation";
 import { Skeleton } from "./ui/skeleton";
 
 export const BoardPageSkeleton = () => {
   const skeletonNoteCount = 5;
+   const path = usePathname();
   return (
     <div className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots">
       <div>
@@ -21,7 +23,7 @@ export const BoardPageSkeleton = () => {
           <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 flex flex-wrap sm:flex-nowrap items-center sm:space-x-3 w-full sm:w-auto">
             <div className="flex justify-between gap-2 items-center w-full sm:w-auto">
               <Skeleton className="h-10 w-42 sm:w-64 pl-10 pr-8" />
-              <Skeleton className="h-10 w-24 rounded-md" />
+              {path !== "/boards/archive" ? <Skeleton className="h-10 w-24 rounded-md" /> : null}
               <Skeleton className="h-10 w-10 rounded-full" />
             </div>
           </div>

--- a/components/board-skeleton.tsx
+++ b/components/board-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "./ui/skeleton";
 
 export const BoardPageSkeleton = () => {
   const skeletonNoteCount = 5;
-   const path = usePathname();
+  const path = usePathname();
   return (
     <div className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots">
       <div>

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -217,7 +217,6 @@ test.describe("Archive Functionality", () => {
     await authenticatedPage.goto("/boards/archive");
 
     await expect(authenticatedPage).toHaveURL("/boards/archive");
-    await expect(authenticatedPage.getByRole("button", { name: "Add note" })).toBeDisabled();
   });
 
   test("should show unarchive button instead of archive button on Archive board", async ({
@@ -452,64 +451,6 @@ test.describe("Archive Functionality", () => {
     expect(thirdTextarea).toContain(testContext.prefix("Third item"));
   });
 
-  test("should disable Add note button on Archive board", async ({
-    authenticatedPage,
-    testContext,
-    testPrisma,
-  }) => {
-    // Create a regular board and note first
-    const board = await testPrisma.board.create({
-      data: {
-        name: testContext.getBoardName("Test Board"),
-        description: testContext.prefix("A test board"),
-        createdBy: testContext.userId,
-        organizationId: testContext.organizationId,
-      },
-    });
-
-    await testPrisma.note.create({
-      data: {
-        color: "#fef3c7",
-        archivedAt: new Date(),
-        createdBy: testContext.userId,
-        boardId: board.id,
-        checklistItems: {
-          create: [
-            {
-              content: testContext.prefix("Archived note content"),
-              checked: false,
-              order: 0,
-            },
-          ],
-        },
-      },
-    });
-
-    // Navigate to archive board
-    await authenticatedPage.goto("/boards/archive");
-
-    // Verify Add note button is disabled
-    const addNoteButton = authenticatedPage.getByRole("button", { name: "Add note" });
-    await expect(addNoteButton).toBeVisible();
-    await expect(addNoteButton).toBeDisabled();
-
-    // Verify button cannot be clicked (should not trigger any action)
-    await addNoteButton.click({ force: true });
-
-    // Wait a moment and verify no new note was created
-    await authenticatedPage.waitForTimeout(1000);
-
-    // Count existing notes (should remain the same)
-    const noteCount = await testPrisma.note.count({
-      where: {
-        createdBy: testContext.userId,
-        deletedAt: null,
-      },
-    });
-
-    // Should still have only the one note we created
-    expect(noteCount).toBe(1);
-  });
 
   test("should enable Add note button on regular boards", async ({
     authenticatedPage,

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -451,7 +451,6 @@ test.describe("Archive Functionality", () => {
     expect(thirdTextarea).toContain(testContext.prefix("Third item"));
   });
 
-
   test("should enable Add note button on regular boards", async ({
     authenticatedPage,
     testContext,


### PR DESCRIPTION
ref: #411 


### Description
- hides the "Add note" button on archives page.
- removed disabled state ` Add note ` and corresponding tests.


### Before:
<img width="544" height="90" alt="image" src="https://github.com/user-attachments/assets/b62c240b-9e52-4eb8-a06a-8bae292797a2" />


### After: 

<img width="544" height="90" alt="image" src="https://github.com/user-attachments/assets/eb07ce02-529c-4253-b6c0-4aa4fd5fdf49" />


### tests
<img width="1038" height="831" alt="Screenshot from 2025-09-11 21-30-02" src="https://github.com/user-attachments/assets/5f96328f-81e4-48f0-8554-5257b02f6170" />

