### PR TITLE
fix: bring back .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+AUTH_SECRET=sample-auth-secret
+AUTH_RESEND_KEY=re_sample_key
+EMAIL_FROM=onboarding@resend.dev
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/gumboard
+
+GOOGLE_CLIENT_ID=your_google-client_id
+GOOGLE_CLIENT_SECRET=your_google-client_secret
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret


### PR DESCRIPTION
pr #775 have delete the env examples. I believe it is an accidental merge 