### PR TITLE
feat(board-settings): show toast on save, enable close button

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -623,9 +623,24 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           sendSlackUpdates: (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
         });
         setBoardSettingsDialog(false);
+        toast("Settings saved", {
+          description: "Your board settings have been updated.",
+        });
+      } else {
+        let errorMsg = "Failed to save settings";
+        try {
+          const errorData = await response.json();
+          errorMsg = errorData?.error || errorMsg;
+        } catch {}
+        toast("Failed to save settings", {
+          description: errorMsg,
+        });
       }
     } catch (error) {
       console.error("Error updating board settings:", error);
+      toast("Failed to save settings", {
+        description: "An unexpected error occurred. Please try again.",
+      });
     }
   };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
           <SessionProvider>
             <UserProvider>
               {children}
-              <Toaster richColors position="bottom-right" />
+              <Toaster richColors position="bottom-right" closeButton />
             </UserProvider>
           </SessionProvider>
         </ThemeProvider>


### PR DESCRIPTION
ref: #411 

- Before: 


https://github.com/user-attachments/assets/cf04d982-6a5a-4755-be4a-e16ef5073f49

- After:


https://github.com/user-attachments/assets/2e1a42af-c94d-47bd-9a41-5e1f838b6457

### AI USAGE:
- I have used Cursor to generate tests, and the implementation was done by myself.

### Self Review: 
- All changes are intuitive, so no additional comments are needed.

<img width="823" height="295" alt="Screenshot From 2025-09-13 10-31-38" src="https://github.com/user-attachments/assets/f73a0b35-f555-4867-a1ce-08c6137defee" />




