### PR TITLE
fix: nav bar layout at boards | small screens only

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -883,7 +883,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
             {/* User Dropdown */}
             <div className="hidden md:block">
-            <ProfileDropdown user={user} />
+              <ProfileDropdown user={user} />
             </div>
           </div>
         </div>

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -827,11 +827,15 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   <EllipsisVertical className="size-4" />
                 </Button>
               )}
+
+              <div className="md:hidden">
+                <ProfileDropdown user={user} />
+              </div>
             </div>
           </div>
 
           {/* Right side - Search, Add Note and User dropdown */}
-          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 grid grid-cols-[1fr_auto] md:grid-cols-[auto_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
+          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 grid grid-cols-[auto_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Search Box */}
             {notes.length > 0 && (
               <div className="relative h-9">
@@ -878,7 +882,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             </Button>
 
             {/* User Dropdown */}
+            <div className="hidden md:block">
             <ProfileDropdown user={user} />
+            </div>
           </div>
         </div>
       </div>

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -838,7 +838,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 grid grid-cols-[auto_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Search Box */}
             {notes.length > 0 && (
-              <div className="relative h-9">
+              <div className="relative h-9 col-span-3 md:col-span-1">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <Search className="h-4 w-4 text-muted-foreground dark:text-zinc-400" />
                 </div>
@@ -875,7 +875,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 }
               }}
               disabled={boardId === "archive"}
-              className="col-span-2 md:col-span-1 flex items-center"
+              className="col-span-3 md:col-span-1 flex items-center"
             >
               <Plus className="w-4 h-4" />
               <span>Add note</span>


### PR DESCRIPTION
ref: #411 


### Description
- changes the layout for `search notes` and `profile dropdown`
- changes made only for small screens.


### Before:

without notes:
<img width="412" height="905" alt="image" src="https://github.com/user-attachments/assets/e97fc299-d03a-4c0f-aa1d-bca817b60076" />

with notes : 
<img width="412" height="905" alt="image" src="https://github.com/user-attachments/assets/b0399093-aab1-4346-ba67-2cb23bb7e2ba" />

### After: 

with notes:
<img width="412" height="905" alt="image" src="https://github.com/user-attachments/assets/0fb1a6ae-3be1-42d2-a751-3595f0b7dffa" />

without notes:
<img width="412" height="905" alt="image" src="https://github.com/user-attachments/assets/ba235664-5cd0-4899-9335-bd87f7668dbd" />



