### PR TITLE
feat: board name should be unique

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -60,6 +60,12 @@ const formSchema = (boards: DashboardBoard[]) =>
       .min(1, "Board name is required")
       .transform((val) => val.trim())
       .superRefine((val, ctx) => {
+        if(val.length === 0){
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Board name cannot be empty",
+          });
+        }
         const exists = boards.some(
           (b) => b.name.trim().toLowerCase() === val.toLowerCase()
         );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -60,15 +60,13 @@ const formSchema = (boards: DashboardBoard[]) =>
       .min(1, "Board name is required")
       .transform((val) => val.trim())
       .superRefine((val, ctx) => {
-        if(val.length === 0){
+        if (val.length === 0) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: "Board name cannot be empty",
           });
         }
-        const exists = boards.some(
-          (b) => b.name.trim().toLowerCase() === val.toLowerCase()
-        );
+        const exists = boards.some((b) => b.name.trim().toLowerCase() === val.toLowerCase());
         if (exists) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -77,7 +75,7 @@ const formSchema = (boards: DashboardBoard[]) =>
         }
       }),
     description: z.string().optional(),
-});
+  });
 
 export default function Dashboard() {
   const [boards, setBoards] = useState<DashboardBoard[]>([]);

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -42,18 +42,17 @@ test.describe("Board Management", () => {
     testContext,
     testPrisma,
   }) => {
-    
     await authenticatedPage.goto("/dashboard");
     const boardName = testContext.getBoardName("Test Board");
     const boardDescription = "Test board description";
 
     await testPrisma.board.create({
-      data:{
+      data: {
         name: boardName,
         description: boardDescription,
         createdBy: testContext.userId,
         organizationId: testContext.organizationId,
-      }
+      },
     });
 
     await authenticatedPage.click('button:has-text("Add Board")');
@@ -61,8 +60,9 @@ test.describe("Board Management", () => {
     await authenticatedPage.fill('input[placeholder*="board description"]', boardDescription);
 
     await authenticatedPage.click('button:has-text("Create Board")');
-    await expect(authenticatedPage.locator("text=A board with this name already exists")).toBeVisible();
-    
+    await expect(
+      authenticatedPage.locator("text=A board with this name already exists")
+    ).toBeVisible();
   });
 
   test("should display empty state when no boards exist", async ({

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -37,6 +37,34 @@ test.describe("Board Management", () => {
     expect(board?.createdBy).toBe(testContext.userId);
   });
 
+  test("should create a new board with unique name only", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    
+    await authenticatedPage.goto("/dashboard");
+    const boardName = testContext.getBoardName("Test Board");
+    const boardDescription = "Test board description";
+
+    await testPrisma.board.create({
+      data:{
+        name: boardName,
+        description: boardDescription,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      }
+    });
+
+    await authenticatedPage.click('button:has-text("Add Board")');
+    await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
+    await authenticatedPage.fill('input[placeholder*="board description"]', boardDescription);
+
+    await authenticatedPage.click('button:has-text("Create Board")');
+    await expect(authenticatedPage.locator("text=A board with this name already exists")).toBeVisible();
+    
+  });
+
   test("should display empty state when no boards exist", async ({
     authenticatedPage,
     testContext,


### PR DESCRIPTION
ref: #411 


### Description
- earlier user can create many boards with same name.
- board name should be unique for identification.
- add related test.


### Before:

<img width="1855" height="905" alt="image" src="https://github.com/user-attachments/assets/78a9980f-86a0-44e6-b7a5-f4d368cac508" />


### After: 

<img width="1855" height="905" alt="image" src="https://github.com/user-attachments/assets/85394f50-eeff-435c-b0d3-fa8976ff9c73" />


### Test
<img width="834" height="118" alt="Screenshot from 2025-09-13 12-46-27" src="https://github.com/user-attachments/assets/207dbd81-b8f3-449e-91f9-638edd516cf9" />
