### PR TITLE
Replace div with button for sign out

### DIFF
--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -16,7 +16,7 @@ export function ProfileDropdown({ user }: Props) {
   return (
     <Popover>
       <PopoverTrigger asChild>
-         <button
+        <button
           type="button"
           aria-label="Open profile menu"
           className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
@@ -34,7 +34,7 @@ export function ProfileDropdown({ user }: Props) {
                   : user?.email?.charAt(0).toUpperCase()}
               </span>
             </AvatarFallback>
-           </Avatar>
+          </Avatar>
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2">
@@ -53,7 +53,7 @@ export function ProfileDropdown({ user }: Props) {
             Settings
           </Link>
 
-         <button
+          <button
             type="button"
             onClick={handleSignOut}
             aria-label="Sign out"

--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -16,8 +16,12 @@ export function ProfileDropdown({ user }: Props) {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Avatar className="w-9 h-9 cursor-pointer">
-          <div className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors ">
+         <button
+          type="button"
+          aria-label="Open profile menu"
+          className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+        >
+          <Avatar className="w-8.5 h-8.5">
             <AvatarImage
               className="w-8.5 h-8.5 rounded-full"
               src={user?.image || ""}
@@ -30,8 +34,8 @@ export function ProfileDropdown({ user }: Props) {
                   : user?.email?.charAt(0).toUpperCase()}
               </span>
             </AvatarFallback>
-          </div>
-        </Avatar>
+           </Avatar>
+        </button>
       </PopoverTrigger>
       <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2">
         <div className="p-2">
@@ -49,12 +53,14 @@ export function ProfileDropdown({ user }: Props) {
             Settings
           </Link>
 
-          <div
+         <button
+            type="button"
             onClick={handleSignOut}
+            aria-label="Sign out"
             className="rounded-lg block font-medium px-3 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer dark:text-white"
           >
             Sign out
-          </div>
+          </button>
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## What Changed

- Replaced the avatar trigger element with a proper `<button>` element.
- Added an `aria-label` to the avatar button for better accessibility.
- Swapped the "Sign out" `<div>` for a semantic `<button>` element, preserving styling and event handlers.
- Added an `aria-label` to the sign-out button to improve screen reader support.

## Why
- **Semantic buttons for interactive elements:**  
  Replacing the avatar trigger and sign-out `<div>` elements with `<button>` tags makes these elements natively focusable and communicates their interactive purpose clearly to assistive technologies.

- **Improved keyboard and screen reader support:**  
  Adding `aria-label` attributes allows screen readers to announce the purpose of the buttons accurately and enables keyboard users to activate these controls reliably, enhancing overall accessibility.

## Checklist
- [x] Self-reviewed for completeness and edge case coverage.  
- [x] Included screenshot of successful Playwright test run.  

## AI Assistance
No AI was used to generate any of this code or description.


Ref #411 
