### PR TITLE
Refactor InviteAcceptPage to use plain searchParams with optional fields

### DIFF
--- a/app/invite/accept/page.tsx
+++ b/app/invite/accept/page.tsx
@@ -126,17 +126,16 @@ async function autoVerifyAndCreateSession(email: string, token: string) {
 }
 
 interface InviteAcceptPageProps {
-  searchParams: Promise<{
+  searchParams: {
     token?: string;
     verified?: string;
-  }>;
+  };
 }
 
 export default async function InviteAcceptPage({ searchParams }: InviteAcceptPageProps) {
   const session = await auth();
-  const resolvedSearchParams = await searchParams;
-  const token = resolvedSearchParams.token;
-  const isJustVerified = resolvedSearchParams.verified === "true";
+  const token = searchParams.token;
+  const isJustVerified = searchParams.verified === "true";
 
   if (!token) {
     return (


### PR DESCRIPTION
## What Changed
- Converted the `InviteAcceptPage` component to accept a plain `searchParams` object as its prop.
- Defined optional `token` and `verified` fields within the `searchParams` object.
- Removed unnecessary `await` logic previously used to extract these values.
- Accessed `token` and `verified` directly from `searchParams`, aligning with how Next.js passes query parameters.


## Why
- **Simplified and clearer component props:**  
  Accepting a plain `searchParams` object with optional fields keeps the props signature explicit and better reflects Next.js conventions.

- **Improved testability and maintainability:**  
  Removing the redundant async logic simplifies the component's logic, making it easier to test and reason about.

## Testing
- Verified via **Playwright HTML report** and console output.

## Screenshots (test run)

<img width="1073" height="443" alt="Screenshot_2025-09-13_13-44-52" src="https://github.com/user-attachments/assets/ae20a49f-6a26-489b-8115-7cfc53003795" />


## Checklist
- [x] Self-reviewed for completeness and edge case coverage.  
- [x] Included screenshot of successful Playwright test run.  

## AI Assistance
No AI was used to generate any of this code or description.


Ref #411 
