### PR TITLE
feat: unify email validation with shared zod schema in sign-in flow

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Mail, ArrowRight, Loader2, ExternalLink } from "lucide-react";
 import { BetaBadge } from "@/components/ui/beta-badge";
-import { isValidEmail } from "@/lib/utils";
+import { inviteSchema } from "@/lib/types";
 import Image from "next/image";
 
 const emailProviders = [
@@ -73,6 +73,7 @@ const oauthProviders = [
     ),
   },
 ];
+const emailSchema = inviteSchema.shape.email;
 
 function SignInContent() {
   const searchParams = useSearchParams();
@@ -110,8 +111,8 @@ function SignInContent() {
     if (!email) return;
 
     const timeoutId = setTimeout(() => {
-      if (email && !isValidEmail(email)) {
-        setEmailError("Please enter a valid email address");
+      if (!emailSchema.safeParse(email).success) {
+                setEmailError("Please enter a valid email address");
       }
     }, 1000);
 
@@ -120,7 +121,8 @@ function SignInContent() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isValidEmail(email)) {
+    const result = emailSchema.safeParse(email);
+    if (!result.success) {
       setEmailError(email ? "Please enter a valid email address" : "Email address is required");
       return;
     }
@@ -128,8 +130,10 @@ function SignInContent() {
     setIsLoading(true);
     try {
       const callbackUrl = searchParams.get("callbackUrl") || "/";
+           const parsedEmail = result.data;
+      setEmail(parsedEmail);
       await signIn("resend", {
-        email,
+        email: parsedEmail,
         redirect: false,
         callbackUrl,
       });

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -112,7 +112,7 @@ function SignInContent() {
 
     const timeoutId = setTimeout(() => {
       if (!emailSchema.safeParse(email).success) {
-                setEmailError("Please enter a valid email address");
+        setEmailError("Please enter a valid email address");
       }
     }, 1000);
 
@@ -130,7 +130,7 @@ function SignInContent() {
     setIsLoading(true);
     try {
       const callbackUrl = searchParams.get("callbackUrl") || "/";
-           const parsedEmail = result.data;
+      const parsedEmail = result.data;
       setEmail(parsedEmail);
       await signIn("resend", {
         email: parsedEmail,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -196,24 +196,3 @@ export function getBoardColumns(columnCount: number, notes: Note[]) {
   }
   return columns;
 }
-
-const EMAIL_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
-
-export function isValidEmail(email: string): boolean {
-  if (!email || typeof email !== "string" || email.length < 5) return false;
-  const atIndex = email.indexOf("@");
-  if (atIndex < 1 || atIndex === email.length - 1 || email.indexOf("@", atIndex + 1) !== -1) {
-    return false;
-  }
-  if (
-    email.includes("..") ||
-    email.startsWith(".") ||
-    email.endsWith(".") ||
-    email.endsWith("@") ||
-    email.startsWith("@")
-  ) {
-    return false;
-  }
-  return EMAIL_REGEX.test(email);
-}


### PR DESCRIPTION
## Summary 

### What
- Dropped custom `isValidEmail` regex.
- Reused shared `emailSchema` with Zod `safeParse`.
- Normalizes emails (trim + lowercase) before submit.

### Why
- Single source of truth for email validation.
- Removes duplicate logic across client/server.
- Keeps checks consistent and easier to maintain.


Screenshot ( All test pass related to email varify)
<img width="1047" height="663" alt="Screenshot_2025-09-13_14-26-06" src="https://github.com/user-attachments/assets/5db9d70f-aad6-4d9a-970f-db87e104426a" />
<img width="1105" height="736" alt="Screenshot_2025-09-13_14-26-55" src="https://github.com/user-attachments/assets/87a4f442-eaad-40ff-b7ce-1c50b3303a1a" />
<img width="1112" height="559" alt="Screenshot_2025-09-13_14-27-50" src="https://github.com/user-attachments/assets/bf0925b7-785a-486e-9dca-c3220261da46" />


### NO AI USED 

REF #411 