### PR TITLE
If already reach limit, the status still Active

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -633,7 +633,7 @@ export default function OrganizationSettingsPage() {
                     <p className="text-sm text-zinc-600 dark:text-zinc-400">{member.email}</p>
                   </div>
                 </div>
-                <div className="flex items-center space-x-2">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   {/* Only show admin toggle to current admins and not for yourself */}
                   {user?.isAdmin && member.id !== user.id && (
                     <Button


### PR DESCRIPTION
Unify expired status chack for date and usage limit

Before:
<img width="985" height="323" alt="4fe24972-d344-450b-8bb1-c4c10473fc7a" src="https://github.com/user-attachments/assets/28f6f3f5-d3a3-4f58-b180-7d7ecd7965ce" />

After:
<img width="963" height="227" alt="9b271d19-5714-4d12-b3b6-33672ef86a2e" src="https://github.com/user-attachments/assets/30df9c9d-9cb0-421f-a9d5-ab80759d15f7" />

No AI used