### PR TITLE
Inconsistent Picker date styling on "Invite team member" section

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -824,8 +824,9 @@ export default function OrganizationSettingsPage() {
                       showOutsideDays={true}
                       classNames={{
                         weekday:
-                        "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",
-                        outside:"text-zinc-400 dark:text-zinc-700 opacity-60 cursor-pointer hover:bg-blue-500 hover:text-white",
+                          "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",
+                        outside:
+                          "text-zinc-400 dark:text-zinc-700 opacity-60 cursor-pointer hover:bg-blue-500 hover:text-white",
                         caption_label: "text-sm font-semibold text-zinc-200 dark:text-zinc-100",
                         day: "cursor-pointer hover:bg-blue-500 hover:text-white rounded-md",
                         day_selected: "bg-blue-500 text-white hover:bg-blue-600 rounded-md",

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -824,10 +824,11 @@ export default function OrganizationSettingsPage() {
                       showOutsideDays={true}
                       classNames={{
                         weekday:
-                          "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",
-                        outside:
-                          "text-zinc-400 dark:text-zinc-700 opacity-60 hover:bg-accent hover:text-accent-foreground cursor-pointer",
-                        caption_label: "text-zinc-900 dark:text-zinc-100",
+                        "w-(--cell-size) text-center text-zinc-900 dark:text-zinc-100 font-normal text-[0.8rem] select-none",
+                        outside:"text-zinc-400 dark:text-zinc-700 opacity-60 cursor-pointer hover:bg-blue-500 hover:text-white",
+                        caption_label: "text-sm font-semibold text-zinc-200 dark:text-zinc-100",
+                        day: "cursor-pointer hover:bg-blue-500 hover:text-white rounded-md",
+                        day_selected: "bg-blue-500 text-white hover:bg-blue-600 rounded-md",
                       }}
                     />
                   </PopoverContent>


### PR DESCRIPTION
Unify calendar colors with one primary for hover, selected and focus

Before:

https://github.com/user-attachments/assets/15dfa8fb-8ae5-4d9c-91ad-3faac9e82615

After:

https://github.com/user-attachments/assets/1cfcc854-a4e1-4cb4-90c7-e442554f21a4


No AI used