### PR TITLE
fix: right margin for profile dropdown

### DIFF
--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -33,7 +33,7 @@ export function ProfileDropdown({ user }: Props) {
           </div>
         </Avatar>
       </PopoverTrigger>
-      <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2 mr-2">
+      <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2 mr-5">
         <div className="p-2">
           <p className="font-medium text-foreground dark:text-zinc-100 truncate max-w-full overflow-hidden whitespace-nowrap">
             {user?.name || user?.email}

--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -33,7 +33,7 @@ export function ProfileDropdown({ user }: Props) {
           </div>
         </Avatar>
       </PopoverTrigger>
-      <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2">
+      <PopoverContent className="w-64 bg-white dark:bg-zinc-900 rounded-lg shadow-lg border border-zinc-100 dark:border-zinc-800 p-2 mr-2">
         <div className="p-2">
           <p className="font-medium text-foreground dark:text-zinc-100 truncate max-w-full overflow-hidden whitespace-nowrap">
             {user?.name || user?.email}


### PR DESCRIPTION
ref: #411 

### Description
- added the right margin to the profile dropdown



### Before:

<img width="548" height="509" alt="image" src="https://github.com/user-attachments/assets/03cc4360-b22c-48e8-a71a-249f03b22b18" />

### After: 
<img width="548" height="509" alt="image" src="https://github.com/user-attachments/assets/43564fba-c9f7-4943-855c-4501b3ba65c6" />


### Test 
purely css changes.
