### PR TITLE
feat(ui): added context menu on board cards to reduce friction 

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -31,6 +31,7 @@ export async function GET() {
         name: true,
         description: true,
         isPublic: true,
+        sendSlackUpdates: true,
         createdBy: true,
         createdAt: true,
         updatedAt: true,
@@ -69,6 +70,7 @@ export async function GET() {
       createdBy: board.createdBy,
       createdAt: board.createdAt,
       updatedAt: board.updatedAt,
+      sendSlackUpdates: board.sendSlackUpdates,
       _count: board._count,
       lastActivityAt: board.notes[0]?.updatedAt ?? board.updatedAt,
     }));

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -315,7 +315,12 @@ export default function Dashboard() {
               </Link>
 
               {boards.map((board) => (
-                <BoardContextMenu setBoards={setBoards} boards={boards} key={board.id} board={board}>
+                <BoardContextMenu
+                  setBoards={setBoards}
+                  boards={boards}
+                  key={board.id}
+                  board={board}
+                >
                   <Card
                     data-board-id={board.id}
                     className="group h-full min-h-34 hover:shadow-lg transition-shadow cursor-pointer whitespace-nowrap bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,6 +42,7 @@ import {
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatLastActivity } from "@/lib/utils";
+import BoardContextMenu from "@/components/board-context-menu";
 
 // Dashboard-specific extended types
 export type DashboardBoard = Board & {
@@ -50,6 +51,7 @@ export type DashboardBoard = Board & {
   updatedAt: string;
   isPublic: boolean;
   lastActivityAt: string;
+  sendSlackUpdates: boolean;
   _count: { notes: number };
 };
 
@@ -313,36 +315,38 @@ export default function Dashboard() {
               </Link>
 
               {boards.map((board) => (
-                <Link href={`/boards/${board.id}`} key={board.id}>
+                <BoardContextMenu setBoards={setBoards} boards={boards} key={board.id} board={board}>
                   <Card
                     data-board-id={board.id}
                     className="group h-full min-h-34 hover:shadow-lg transition-shadow cursor-pointer whitespace-nowrap bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800"
                   >
-                    <CardHeader>
-                      <div className="grid grid-cols-[1fr_auto] items-start justify-between gap-2">
-                        <CardTitle
-                          className="text-lg dark:text-zinc-100 truncate"
-                          title={board.name}
-                        >
-                          {board.name}
-                        </CardTitle>
-                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 mt-0.5">
-                          {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
-                        </span>
-                      </div>
-                    </CardHeader>
-                    <CardContent>
-                      {board.description && (
-                        <p className="text-slate-600 dark:text-zinc-300 truncate mb-2">
-                          {board.description}
+                    <Link href={`/boards/${board.id}`} key={board.id}>
+                      <CardHeader>
+                        <div className="grid grid-cols-[1fr_auto] items-start justify-between gap-2">
+                          <CardTitle
+                            className="text-lg dark:text-zinc-100 truncate"
+                            title={board.name}
+                          >
+                            {board.name}
+                          </CardTitle>
+                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 mt-0.5">
+                            {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
+                          </span>
+                        </div>
+                      </CardHeader>
+                      <CardContent>
+                        {board.description && (
+                          <p className="text-slate-600 dark:text-zinc-300 truncate mb-2">
+                            {board.description}
+                          </p>
+                        )}
+                        <p className="text-xs text-slate-500 dark:text-zinc-400">
+                          Last active: {formatLastActivity(board.lastActivityAt)}
                         </p>
-                      )}
-                      <p className="text-xs text-slate-500 dark:text-zinc-400">
-                        Last active: {formatLastActivity(board.lastActivityAt)}
-                      </p>
-                    </CardContent>
+                      </CardContent>
+                    </Link>
                   </Card>
-                </Link>
+                </BoardContextMenu>
               ))}
             </div>
           </>

--- a/components/board-context-menu.tsx
+++ b/components/board-context-menu.tsx
@@ -64,7 +64,7 @@ export default function BoardContextMenu({
   return (
     <ContextMenu key={board.id}>
       <ContextMenuTrigger>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="w-52">
+      <ContextMenuContent className="w-52" data-testid="board-card-context-menu">
         <ContextMenuItem onClick={() => window.open(`/boards/${board.id}`, "_blank")}>
           <SquareArrowOutUpRight />
           <p>Open in new tab</p>

--- a/components/board-context-menu.tsx
+++ b/components/board-context-menu.tsx
@@ -1,10 +1,10 @@
 import { DashboardBoard } from "@/app/dashboard/page";
 import {
-    ContextMenu,
-    ContextMenuCheckboxItem,
-    ContextMenuContent,
-    ContextMenuItem,
-    ContextMenuTrigger,
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { SquareArrowOutUpRight } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -16,47 +16,50 @@ type BoardContextMenuProps = {
   setBoards: (boards: DashboardBoard[]) => void;
 };
 
-export default function BoardContextMenu({ children, board , boards, setBoards }: BoardContextMenuProps) {
-    const { resolvedTheme } = useTheme()
-    const handleDeleteBoard = async () => {
-      try {
-        const response = await fetch(`/api/boards/${board.id}`, {
-          method: "DELETE",
-        });
-  
-        if (response.ok) {
-            setBoards(boards.filter((b) => b.id !== board.id));
-        } else {
-          const errorData = await response.json();
-          console.error("Failed to delete board:", errorData.error);
-        }
-      } catch (error) {
-        console.error("Error deleting board:", error);
+export default function BoardContextMenu({
+  children,
+  board,
+  boards,
+  setBoards,
+}: BoardContextMenuProps) {
+  const { resolvedTheme } = useTheme();
+  const handleDeleteBoard = async () => {
+    try {
+      const response = await fetch(`/api/boards/${board.id}`, {
+        method: "DELETE",
+      });
+
+      if (response.ok) {
+        setBoards(boards.filter((b) => b.id !== board.id));
+      } else {
+        const errorData = await response.json();
+        console.error("Failed to delete board:", errorData.error);
       }
+    } catch (error) {
+      console.error("Error deleting board:", error);
     }
+  };
 
-    const handleSlackUpdateChekbox = async () => {
-      try {
-        const response = await fetch(`/api/boards/${board.id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sendSlackUpdates: !board.sendSlackUpdates }),
-        });
-  
-        if (response.ok) {
-          const { board } = await response.json();
-          console.log(board);
-          setBoards(boards.map((b) => (b.id === board.id ? board : b)));
-        } else {
-          const errorData = await response.json();
-          console.error("Failed to update board:", errorData.error);
-        }
-      } catch (error) {
-        console.error("Error updating board:", error);
+  const handleSlackUpdateChekbox = async () => {
+    try {
+      const response = await fetch(`/api/boards/${board.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sendSlackUpdates: !board.sendSlackUpdates }),
+      });
+
+      if (response.ok) {
+        const { board } = await response.json();
+        console.log(board);
+        setBoards(boards.map((b) => (b.id === board.id ? board : b)));
+      } else {
+        const errorData = await response.json();
+        console.error("Failed to update board:", errorData.error);
       }
+    } catch (error) {
+      console.error("Error updating board:", error);
     }
-
-
+  };
 
   return (
     <ContextMenu key={board.id}>
@@ -66,7 +69,12 @@ export default function BoardContextMenu({ children, board , boards, setBoards }
           <SquareArrowOutUpRight />
           <p>Open in new tab</p>
         </ContextMenuItem>
-        <ContextMenuCheckboxItem checked={board.sendSlackUpdates} onClick={handleSlackUpdateChekbox}>Slack Updates</ContextMenuCheckboxItem>
+        <ContextMenuCheckboxItem
+          checked={board.sendSlackUpdates}
+          onClick={handleSlackUpdateChekbox}
+        >
+          Slack Updates
+        </ContextMenuCheckboxItem>
         <ContextMenuItem variant="destructive" onClick={handleDeleteBoard}>
           <svg
             fill={resolvedTheme === "dark" ? "#fff" : "#000"}

--- a/components/board-context-menu.tsx
+++ b/components/board-context-menu.tsx
@@ -50,7 +50,6 @@ export default function BoardContextMenu({
 
       if (response.ok) {
         const { board } = await response.json();
-        console.log(board);
         setBoards(boards.map((b) => (b.id === board.id ? board : b)));
       } else {
         const errorData = await response.json();

--- a/components/board-context-menu.tsx
+++ b/components/board-context-menu.tsx
@@ -1,0 +1,100 @@
+import { DashboardBoard } from "@/app/dashboard/page";
+import {
+    ContextMenu,
+    ContextMenuCheckboxItem,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { SquareArrowOutUpRight } from "lucide-react";
+import { useTheme } from "next-themes";
+
+type BoardContextMenuProps = {
+  children: React.ReactNode;
+  board: DashboardBoard;
+  boards: DashboardBoard[];
+  setBoards: (boards: DashboardBoard[]) => void;
+};
+
+export default function BoardContextMenu({ children, board , boards, setBoards }: BoardContextMenuProps) {
+    const { resolvedTheme } = useTheme()
+    const handleDeleteBoard = async () => {
+      try {
+        const response = await fetch(`/api/boards/${board.id}`, {
+          method: "DELETE",
+        });
+  
+        if (response.ok) {
+            setBoards(boards.filter((b) => b.id !== board.id));
+        } else {
+          const errorData = await response.json();
+          console.error("Failed to delete board:", errorData.error);
+        }
+      } catch (error) {
+        console.error("Error deleting board:", error);
+      }
+    }
+
+    const handleSlackUpdateChekbox = async () => {
+      try {
+        const response = await fetch(`/api/boards/${board.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sendSlackUpdates: !board.sendSlackUpdates }),
+        });
+  
+        if (response.ok) {
+          const { board } = await response.json();
+          console.log(board);
+          setBoards(boards.map((b) => (b.id === board.id ? board : b)));
+        } else {
+          const errorData = await response.json();
+          console.error("Failed to update board:", errorData.error);
+        }
+      } catch (error) {
+        console.error("Error updating board:", error);
+      }
+    }
+
+
+
+  return (
+    <ContextMenu key={board.id}>
+      <ContextMenuTrigger>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        <ContextMenuItem onClick={() => window.open(`/boards/${board.id}`, "_blank")}>
+          <SquareArrowOutUpRight />
+          <p>Open in new tab</p>
+        </ContextMenuItem>
+        <ContextMenuCheckboxItem checked={board.sendSlackUpdates} onClick={handleSlackUpdateChekbox}>Slack Updates</ContextMenuCheckboxItem>
+        <ContextMenuItem variant="destructive" onClick={handleDeleteBoard}>
+          <svg
+            fill={resolvedTheme === "dark" ? "#fff" : "#000"}
+            height="200px"
+            width="200px"
+            version="1.1"
+            id="Layer_1"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 458.5 458.5"
+          >
+            <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+            <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+            <g id="SVGRepo_iconCarrier">
+              <g>
+                <g>
+                  <g>
+                    <path d="M382.078,57.069h-89.78C289.128,25.075,262.064,0,229.249,0S169.37,25.075,166.2,57.069H76.421 c-26.938,0-48.854,21.916-48.854,48.854c0,26.125,20.613,47.524,46.429,48.793V399.5c0,32.533,26.467,59,59,59h192.508 c32.533,0,59-26.467,59-59V154.717c25.816-1.269,46.429-22.668,46.429-48.793C430.933,78.985,409.017,57.069,382.078,57.069z M229.249,30c16.244,0,29.807,11.673,32.76,27.069h-65.52C199.442,41.673,213.005,30,229.249,30z M354.503,399.501 c0,15.991-13.009,29-29,29H132.995c-15.991,0-29-13.009-29-29V154.778c12.244,0,240.932,0,250.508,0V399.501z M382.078,124.778 c-3.127,0-302.998,0-305.657,0c-10.396,0-18.854-8.458-18.854-18.854S66.025,87.07,76.421,87.07h305.657 c10.396,0,18.854,8.458,18.854,18.854S392.475,124.778,382.078,124.778z"></path>{" "}
+                    <path d="M229.249,392.323c8.284,0,15-6.716,15-15V203.618c0-8.284-6.715-15-15-15c-8.284,0-15,6.716-15,15v173.705 C214.249,385.607,220.965,392.323,229.249,392.323z"></path>{" "}
+                    <path d="M306.671,392.323c8.284,0,15-6.716,15-15V203.618c0-8.284-6.716-15-15-15s-15,6.716-15,15v173.705 C291.671,385.607,298.387,392.323,306.671,392.323z"></path>{" "}
+                    <path d="M151.828,392.323c8.284,0,15-6.716,15-15V203.618c0-8.284-6.716-15-15-15c-8.284,0-15,6.716-15,15v173.705 C136.828,385.607,143.544,392.323,151.828,392.323z"></path>{" "}
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+          <p>Delete Board</p>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
+}
+
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
+}
+
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "bg-white dark:bg-zinc-900 text-white  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto border border-zinc-200 dark:border-zinc-800 rounded-md p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-zinc-100 dark:focus:bg-zinc-800 text-black dark:text-white focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "focus:bg-zinc-100 dark:focus:bg-zinc-800 text-black dark:text-white focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn("text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.2",
+        "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
@@ -2780,6 +2781,32 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2809,6 +2836,40 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.14",
@@ -2969,6 +3030,150 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz",
@@ -3108,6 +3313,43 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.2",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",

--- a/tests/e2e/dashboard/board-card.spec.ts
+++ b/tests/e2e/dashboard/board-card.spec.ts
@@ -77,3 +77,101 @@ test.describe("Board Card", () => {
     await expect(noteCount).toHaveText(/^\d+ note(s)?$/);
   });
 });
+
+test.describe("Board Card context menu", () => {
+  test("should open context menu on right click", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Test Board 1"),
+        description: testContext.prefix("A test board 1"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/dashboard`);
+    const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+    console.log(boardCard);
+
+    await boardCard.click({ button: "right" });
+    await expect(authenticatedPage.getByTestId("board-card-context-menu")).toBeVisible();
+  });
+
+  test("should toggle slack updates status on click", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Test Board 1"),
+        description: testContext.prefix("A test board 1"),
+        sendSlackUpdates: true,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/dashboard`);
+    const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+    await boardCard.click({ button: "right" });
+    await authenticatedPage
+      .getByTestId("board-card-context-menu")
+      .getByText("Slack Updates")
+      .click();
+    await expect(authenticatedPage.getByTestId("board-card-context-menu")).not.toBeVisible();
+
+    const updatedBoard = await testPrisma.board.findFirst({
+      where: {
+        id: board.id,
+        organizationId: testContext.organizationId,
+      },
+      select: {
+        sendSlackUpdates: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(updatedBoard?.sendSlackUpdates).toBe(false);
+  });
+
+  test("should delete board on click of delete button", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Test Board 1"),
+        description: testContext.prefix("A test board 1"),
+        sendSlackUpdates: true,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/dashboard`);
+    const boardCard = authenticatedPage.locator(`[href="/boards/${board.id}"]`);
+    await boardCard.click({ button: "right" });
+    await authenticatedPage
+      .getByTestId("board-card-context-menu")
+      .getByText("Delete Board")
+      .click();
+
+    await expect(authenticatedPage.getByTestId("board-card-context-menu")).not.toBeVisible();
+    await expect(authenticatedPage.locator(`[href="/boards/${board.id}"]`)).not.toBeVisible();
+
+    const updatedBoard = await testPrisma.board.findFirst({
+      where: {
+        id: board.id,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    expect(updatedBoard).toBeNull();
+  });
+});


### PR DESCRIPTION
# Description
Added a context menu on board cards in dashboard with features of deleting board, turning slack updates on and off and open in new tab

- [x] Added tests 

https://github.com/user-attachments/assets/473952f1-2e21-484e-9b4f-94bda2e4d81f

# AI Disclosure
Gemini CLI was used to modify shadcn context menu according to our design system 