### PR TITLE
fix: display note instead of notes for count less than 1

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -327,7 +327,7 @@ export default function Dashboard() {
                           {board.name}
                         </CardTitle>
                         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 mt-0.5">
-                          {board._count.notes} {board._count.notes === 1 ? "note" : "notes"}
+                          {board._count.notes} {board._count.notes <= 1 ? "note" : "notes"}
                         </span>
                       </div>
                     </CardHeader>

--- a/tests/e2e/dashboard/activity-tracking.spec.ts
+++ b/tests/e2e/dashboard/activity-tracking.spec.ts
@@ -92,7 +92,7 @@ test.describe("Activity Tracking", () => {
     const boardCard = authenticatedPage.locator(`[data-board-id="${board.id}"]`);
     await expect(boardCard).toBeVisible({ timeout: 10000 });
     await expect(boardCard).toContainText("Last active:");
-    await expect(boardCard).toContainText("0 notes");
+    await expect(boardCard).toContainText("0 note");
 
     const boardText = await boardCard.textContent();
     expect(boardText).toMatch(/Last active: (Just now|\d+[dhms])/);


### PR DESCRIPTION
ref: #411 

### Description
- should display `0 note` not `0 notes`.
- should display `1 note` not `1 notes`.


### Before:

<img width="372" height="204" alt="image" src="https://github.com/user-attachments/assets/1a571580-533d-4a60-8de3-030ee0a51604" />

### After: 

<img width="372" height="204" alt="image" src="https://github.com/user-attachments/assets/bd80587c-93ff-47ca-bec2-f730040ea387" />


### Tests
<img width="749" height="204" alt="image" src="https://github.com/user-attachments/assets/a4ced820-ef53-4d68-a84c-6829336ff11f" />


### Ai usage 
none