### PR TITLE
fix: dark mode for boards

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -906,7 +906,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   style={{
                     backgroundColor:
                       resolvedTheme === "dark"
-                        ? `color-mix(in srgb, ${note.color} 80%, black)`
+                        ? `color-mix(in srgb, ${note.color} 70%, black)`
                         : note.color,
                   }}
                 />

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -904,7 +904,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   showBoardName={boardId === "all-notes" || boardId === "archive"}
                   className="shadow-md shadow-black/10 p-4"
                   style={{
-                    backgroundColor: resolvedTheme === "dark" ? "#18181B" : note.color,
+                    backgroundColor: resolvedTheme === "dark" ? `color-mix(in srgb, ${note.color} 80%, black)` : note.color,
                   }}
                 />
               ))}

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -904,7 +904,10 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   showBoardName={boardId === "all-notes" || boardId === "archive"}
                   className="shadow-md shadow-black/10 p-4"
                   style={{
-                    backgroundColor: resolvedTheme === "dark" ? `color-mix(in srgb, ${note.color} 80%, black)` : note.color,
+                    backgroundColor:
+                      resolvedTheme === "dark"
+                        ? `color-mix(in srgb, ${note.color} 80%, black)`
+                        : note.color,
                   }}
                 />
               ))}

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -118,7 +118,7 @@ export function ChecklistItem({
       <Checkbox
         checked={item.checked}
         onCheckedChange={() => !readonly && onToggle?.(item.id)}
-        className="border-zinc-500 bg-white/50 dark:bg-zinc-800 dark:border-zinc-600 mt-1.5 text-zinc-900 dark:text-zinc-100"
+        className="border-zinc-500 bg-white/50 dark:bg-zinc-400 dark:opacity-70 dark:border-zinc-600 mt-1.5 text-zinc-900 dark:text-zinc-100"
         disabled={readonly}
       />
 
@@ -130,7 +130,7 @@ export function ChecklistItem({
         placeholder={isNewItem ? "Start typing…" : undefined}
         className={cn(
           "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
-          item.checked && "text-zinc-500 dark:text-zinc-500 line-through"
+          item.checked && "text-zinc-500 dark:text-zinc-700 line-through"
         )}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
@@ -164,7 +164,7 @@ export function ChecklistItem({
         <Button
           variant="ghost"
           size="icon"
-          className="h-6 w-6 opacity-50 rounded-sm hover:bg-white/20 md:opacity-0 md:group-hover/item:opacity-50 md:hover:opacity-100 text-zinc-500 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white"
+          className="h-6 w-6 opacity-50 rounded-sm hover:bg-white/20 md:opacity-0 md:group-hover/item:opacity-50 md:hover:opacity-100 text-zinc-500 hover:text-zinc-900 dark:text-zinc-700 dark:hover:text-white"
           onMouseDown={() => {
             deletingRef.current = true;
           }}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -373,7 +373,7 @@ export function Note({
               {showBoardName && note.board && (
                 <Link
                   href={`/boards/${note.board.id}`}
-                  className="text-xs text-blue-600 dark:text-blue-400 opacity-80 font-medium truncate max-w-20 hover:opacity-100 transition-opacity"
+                  className="text-xs text-blue-600 dark:text-blue-700 opacity-80 font-medium truncate max-w-20 hover:opacity-100 transition-opacity"
                 >
                   {note.board.name}
                 </Link>
@@ -392,7 +392,7 @@ export function Note({
                       e.stopPropagation();
                       onCopy?.(note);
                     }}
-                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white hover:bg-white/20 rounded"
+                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-zinc-700 dark:hover:text-white hover:bg-white/20 rounded"
                     variant="ghost"
                     size="icon"
                   >
@@ -413,7 +413,7 @@ export function Note({
                       e.stopPropagation();
                       onDelete?.(note.id);
                     }}
-                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white hover:bg-white/20 rounded"
+                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-zinc-700 dark:hover:text-white hover:bg-white/20 rounded"
                     variant="ghost"
                     size="icon"
                   >
@@ -433,7 +433,7 @@ export function Note({
                       e.stopPropagation();
                       onArchive(note.id);
                     }}
-                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-gray-400 dark:hover:text-white hover:bg-white/20 rounded"
+                    className="p-1 text-zinc-600 hover:text-zinc-900 dark:text-gray-700 dark:hover:text-white hover:bg-white/20 rounded"
                     variant="ghost"
                     size="icon"
                     aria-label="Archive note"

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -334,7 +334,7 @@ export function Note({
   return (
     <div
       className={cn(
-        "relative select-none group transition-shadow duration-200 flex flex-col dark:border-gray-600 dark:bg-zinc-900 box-border border rounded-lg",
+        "relative select-none group transition-shadow duration-200 flex flex-col dark:border-gray-300 box-border border rounded-lg",
         // Focus highlight when any child is focused/being typed into
         "focus-within:ring-2 focus-within:ring-sky-500 dark:focus-within:ring-sky-400 focus-within:ring-offset-1 focus-within:ring-offset-white dark:focus-within:ring-offset-zinc-900",
         // Light theme variant

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -334,7 +334,7 @@ export function Note({
   return (
     <div
       className={cn(
-        "relative select-none group transition-shadow duration-200 flex flex-col dark:border-gray-300 box-border border rounded-lg",
+        "relative select-none group transition-shadow duration-200 flex flex-col dark:border-gray-400 box-border border rounded-lg",
         // Focus highlight when any child is focused/being typed into
         "focus-within:ring-2 focus-within:ring-sky-500 dark:focus-within:ring-sky-400 focus-within:ring-offset-1 focus-within:ring-offset-white dark:focus-within:ring-offset-zinc-900",
         // Light theme variant


### PR DESCRIPTION
ref: #411 

### Description

- Fixes the dark mode theme / inconsistencies.
- made the board eye friendly on dark light.

### Before:

<img width="1849" height="965" alt="image" src="https://github.com/user-attachments/assets/e473fee3-4357-4b0c-ae23-373fd5d5f9df" />


### After: 

<img width="1849" height="965" alt="image" src="https://github.com/user-attachments/assets/471f2bce-dbde-4382-8c36-3a00d3897679" />

### Ai usage 
none