### PR TITLE
fix: board nav layout issue on small-to-medium screens

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -688,7 +688,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     <div className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots">
       <div>
         <div className="mx-0.5 md:mx-5 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-2 items-center h-auto md:h-16 p-2 md:p-0">
-          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 md:w-fit grid grid-cols-[1fr_auto] md:grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
+          <div className="bg-white dark:bg-zinc-900 shadow-sm border border-zinc-100 rounded-lg dark:border-zinc-800 mt-2 py-2 px-3 md:w-fit grid grid-cols-[1fr_auto] sm:grid-cols-[1fr_auto_auto_auto] md:grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center auto-rows-auto grid-flow-dense">
             {/* Company Name */}
             <Link href="/dashboard" className="flex-shrink-0 pl-1 w-fit">
               <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-3">


### PR DESCRIPTION
### Description:

Top section of nav layout in boards is not properly aligned between `sm` and `md` breakpoints

Part of #411   

### Before / After:

#### Before:

 <table>
 <tr><th>Dark theme</th><th>Light theme</th></tr>
 <tr>
 <td> 
<img width="642" height="394" alt="Screenshot 2025-09-14 at 11 29 32 PM" src="https://github.com/user-attachments/assets/3e013fa2-1b8c-4182-884e-9a3aa58dc063" />
 </td>
 <td>
<img width="645" height="395" alt="Screenshot 2025-09-14 at 11 29 48 PM" src="https://github.com/user-attachments/assets/ca9a3ec3-13e5-409c-aa7d-fb7aee42ce66" />
 </td>
 </tr>
 </table>

#### After:

 <table>
 <tr><th>Dark theme</th><th>Light theme</th></tr>
 <tr>
 <td> 
<img width="644" height="350" alt="Screenshot 2025-09-14 at 11 28 59 PM" src="https://github.com/user-attachments/assets/44018440-66ea-4adc-8698-521f80836715" />
 </td>
 <td>
<img width="645" height="355" alt="Screenshot 2025-09-14 at 11 28 45 PM" src="https://github.com/user-attachments/assets/23fe492e-842d-40b8-9ba7-1cd14c3eadc7" />
 </td>
 </tr>
 </table>


### Test Suite / Related tests:

<img width="1149" height="811" alt="Screenshot 2025-09-14 at 11 18 58 PM" src="https://github.com/user-attachments/assets/6dac2b6c-f4d0-4ec9-a8f7-d56891a046b9" />

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.
>Self-review: All changes are intuitive, so no additional comments are needed.

