### PR TITLE
Fix: update note deletion logic

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -673,10 +673,10 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   // Multi-select handlers
   const handleNoteClick = (noteId: string, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent event from bubbling to board area
-    
+
     if (event.ctrlKey || event.metaKey) {
       event.preventDefault();
-      setSelectedNotes(prev => {
+      setSelectedNotes((prev) => {
         const newSet = new Set(prev);
         if (newSet.has(noteId)) {
           newSet.delete(noteId);
@@ -695,7 +695,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   const handleNoteDoubleClick = (noteId: string, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent event from bubbling to board area
-    
+
     if (!isMultiSelectMode) {
       event.preventDefault();
       setSelectedNotes(new Set([noteId]));
@@ -704,7 +704,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   };
 
   const handleSelectAll = () => {
-    setSelectedNotes(new Set(filteredNotes.map(note => note.id)));
+    setSelectedNotes(new Set(filteredNotes.map((note) => note.id)));
     setIsMultiSelectMode(true);
   };
 
@@ -718,14 +718,14 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     if (notesToDelete.length === 0) return;
 
     // Optimistically remove from UI
-    setNotes(prev => prev.filter(note => !selectedNotes.has(note.id)));
+    setNotes((prev) => prev.filter((note) => !selectedNotes.has(note.id)));
     setSelectedNotes(new Set());
     setIsMultiSelectMode(false);
 
     // Delete from server
     try {
-      const deletePromises = notesToDelete.map(noteId => {
-        const note = notes.find(n => n.id === noteId);
+      const deletePromises = notesToDelete.map((noteId) => {
+        const note = notes.find((n) => n.id === noteId);
         const targetBoardId = note?.board?.id ?? note?.boardId;
         return fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
           method: "DELETE",
@@ -735,21 +735,21 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       const results = await Promise.allSettled(deletePromises);
       const failedDeletes = results
         .map((result, index) => ({ result, noteId: notesToDelete[index] }))
-        .filter(({ result }) => result.status === 'rejected');
+        .filter(({ result }) => result.status === "rejected");
 
       if (failedDeletes.length > 0) {
         // Re-add failed notes to UI
         const failedNoteIds = failedDeletes.map(({ noteId }) => noteId);
-        const failedNotes = notes.filter(note => failedNoteIds.includes(note.id));
-        setNotes(prev => [...prev, ...failedNotes]);
-        
+        const failedNotes = notes.filter((note) => failedNoteIds.includes(note.id));
+        setNotes((prev) => [...prev, ...failedNotes]);
+
         setErrorDialog({
           open: true,
           title: "Failed to delete some notes",
           description: `Failed to delete ${failedDeletes.length} out of ${notesToDelete.length} notes.`,
         });
       } else {
-        toast(`Deleted ${notesToDelete.length} note${notesToDelete.length > 1 ? 's' : ''}`);
+        toast(`Deleted ${notesToDelete.length} note${notesToDelete.length > 1 ? "s" : ""}`);
       }
     } catch (error) {
       console.error("Error bulk deleting notes:", error);
@@ -766,14 +766,14 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     if (notesToArchive.length === 0) return;
 
     // Optimistically remove from UI
-    setNotes(prev => prev.filter(note => !selectedNotes.has(note.id)));
+    setNotes((prev) => prev.filter((note) => !selectedNotes.has(note.id)));
     setSelectedNotes(new Set());
     setIsMultiSelectMode(false);
 
     // Archive on server
     try {
-      const archivePromises = notesToArchive.map(noteId => {
-        const note = notes.find(n => n.id === noteId);
+      const archivePromises = notesToArchive.map((noteId) => {
+        const note = notes.find((n) => n.id === noteId);
         const targetBoardId = note?.board?.id ?? note?.boardId;
         return fetch(`/api/boards/${targetBoardId}/notes/${noteId}`, {
           method: "PUT",
@@ -785,21 +785,21 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       const results = await Promise.allSettled(archivePromises);
       const failedArchives = results
         .map((result, index) => ({ result, noteId: notesToArchive[index] }))
-        .filter(({ result }) => result.status === 'rejected');
+        .filter(({ result }) => result.status === "rejected");
 
       if (failedArchives.length > 0) {
         // Re-add failed notes to UI
         const failedNoteIds = failedArchives.map(({ noteId }) => noteId);
-        const failedNotes = notes.filter(note => failedNoteIds.includes(note.id));
-        setNotes(prev => [...prev, ...failedNotes]);
-        
+        const failedNotes = notes.filter((note) => failedNoteIds.includes(note.id));
+        setNotes((prev) => [...prev, ...failedNotes]);
+
         setErrorDialog({
           open: true,
           title: "Failed to archive some notes",
           description: `Failed to archive ${failedArchives.length} out of ${notesToArchive.length} notes.`,
         });
       } else {
-        toast(`Archived ${notesToArchive.length} note${notesToArchive.length > 1 ? 's' : ''}`);
+        toast(`Archived ${notesToArchive.length} note${notesToArchive.length > 1 ? "s" : ""}`);
       }
     } catch (error) {
       console.error("Error bulk archiving notes:", error);
@@ -815,17 +815,17 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.ctrlKey || event.metaKey) {
-        if (event.key === 'a') {
+        if (event.key === "a") {
           event.preventDefault();
           handleSelectAll();
         }
-      } else if (event.key === 'Escape') {
+      } else if (event.key === "Escape") {
         handleClearSelection();
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [filteredNotes]);
 
   if (userLoading || notesloading) {
@@ -846,7 +846,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   }
 
   return (
-    <div 
+    <div
       className="min-h-screen max-w-screen bg-zinc-100 dark:bg-zinc-800 bg-dots"
       onClick={(e) => {
         // Clear selection when clicking anywhere on the page except on notes
@@ -1107,9 +1107,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
         {isMultiSelectMode && selectedNotes.size === 0 && (
           <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
             <p className="text-sm text-blue-700 dark:text-blue-300">
-              <strong>Multi-select mode:</strong> Hold Ctrl (or Cmd on Mac) and click on notes to select multiple, or double-click any note to start selecting. 
-              Click anywhere outside notes to deselect all. Press <kbd className="px-1 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-xs">Ctrl+A</kbd> to select all, 
-              or <kbd className="px-1 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-xs">Esc</kbd> to exit.
+              <strong>Multi-select mode:</strong> Hold Ctrl (or Cmd on Mac) and click on notes to
+              select multiple, or double-click any note to start selecting. Click anywhere outside
+              notes to deselect all. Press{" "}
+              <kbd className="px-1 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-xs">Ctrl+A</kbd>{" "}
+              to select all, or{" "}
+              <kbd className="px-1 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-xs">Esc</kbd> to
+              exit.
             </p>
           </div>
         )}
@@ -1128,9 +1132,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                   onCopy={handleCopyNote}
                   showBoardName={boardId === "all-notes" || boardId === "archive"}
                   className={`shadow-md shadow-black/10 p-4 cursor-pointer transition-all duration-200 ${
-                    selectedNotes.has(note.id) 
-                      ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-white dark:ring-offset-zinc-800' 
-                      : ''
+                    selectedNotes.has(note.id)
+                      ? "ring-2 ring-blue-500 ring-offset-2 ring-offset-white dark:ring-offset-zinc-800"
+                      : ""
                   }`}
                   style={{
                     backgroundColor: resolvedTheme === "dark" ? "#18181B" : note.color,

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -976,22 +976,23 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 />
               </div>
               {boardId !== "all-notes" && boardId !== "archive" && (
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label="Board actions"
-                      title="Board actions"
-                      className="flex items-center size-9"
-                    >
-                      <EllipsisVertical className="size-4" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-48 p-1" align="end">
-                    <div className="flex flex-col">
-                      {selectedNotes.size > 0 && (
-                        <>
+                <div className="flex items-center">
+                  {/* Bulk Actions Menu - Only show when notes are selected */}
+                  {selectedNotes.size > 0 && (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label="Bulk actions"
+                          title="Bulk actions"
+                          className="flex items-center size-9 mr-1"
+                        >
+                          <EllipsisVertical className="size-4" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-48 p-1" align="end">
+                        <div className="flex flex-col">
                           <Button
                             variant="ghost"
                             size="sm"
@@ -1012,29 +1013,32 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                               Archive ({selectedNotes.size})
                             </Button>
                           )}
-                          <div className="border-t border-zinc-200 dark:border-zinc-700 my-1" />
-                        </>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setBoardSettings({
-                            name: board?.name || "",
-                            description: board?.description || "",
-                            isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
-                            sendSlackUpdates:
-                              (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
-                          });
-                          setBoardSettingsDialog(true);
-                        }}
-                        className="justify-start"
-                      >
-                        Board Settings
-                      </Button>
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  )}
+                  
+                  {/* Board Settings Button - Always visible for tests */}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setBoardSettings({
+                        name: board?.name || "",
+                        description: board?.description || "",
+                        isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
+                        sendSlackUpdates:
+                          (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+                      });
+                      setBoardSettingsDialog(true);
+                    }}
+                    aria-label="Board settings"
+                    title="Board settings"
+                    className="flex items-center size-9"
+                  >
+                    <EllipsisVertical className="size-4" />
+                  </Button>
+                </div>
               )}
             </div>
           </div>

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -425,7 +425,7 @@ export function Note({
                 </TooltipContent>
               </Tooltip>
             )}
-            {canEdit && (
+            {canEdit && !note.archivedAt && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -68,6 +68,9 @@ interface NoteProps {
   showBoardName?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  isSelected?: boolean;
+  onNoteClick?: (event: React.MouseEvent) => void;
+  onNoteDoubleClick?: (event: React.MouseEvent) => void;
 }
 
 export function Note({
@@ -83,6 +86,9 @@ export function Note({
   className,
   syncDB = true,
   style,
+  isSelected = false,
+  onNoteClick,
+  onNoteDoubleClick,
 }: NoteProps) {
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [editingItemContent, setEditingItemContent] = useState("");
@@ -349,10 +355,21 @@ export function Note({
       data-testid="note-card"
       onFocusCapture={() => {}}
       onBlurCapture={() => {}}
+      onClick={onNoteClick}
+      onDoubleClick={onNoteDoubleClick}
       style={style}
     >
       <div className="flex items-start justify-between mb-2 flex-shrink-0">
         <div className="flex-1 min-w-0 flex items-center space-x-2">
+          {isSelected && (
+            <div className="flex-shrink-0">
+              <div className="w-4 h-4 bg-blue-500 rounded-sm flex items-center justify-center">
+                <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </div>
+            </div>
+          )}
           <Avatar className="h-7 w-7">
             <AvatarFallback className="bg-white/50 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 text-sm font-semibold">
               {note.user.name

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -365,7 +365,11 @@ export function Note({
             <div className="flex-shrink-0">
               <div className="w-4 h-4 bg-blue-500 rounded-sm flex items-center justify-center">
                 <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </div>
             </div>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -108,6 +108,18 @@ function Calendar({
         Root: ({ className, rootRef, ...props }) => {
           return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
         },
+        Day: ({ className, ...props }: any) => {
+          // Attempt to read the underlying Date from react-day-picker's props shape
+          const date: Date | undefined = (props as any)?.day?.date || (props as any)?.date;
+          const formatYYYYMMDD = (d: Date) => {
+            const y = d.getFullYear();
+            const m = String(d.getMonth() + 1).padStart(2, "0");
+            const day = String(d.getDate()).padStart(2, "0");
+            return `${y}-${m}-${day}`;
+          };
+          const dataDay = date ? formatYYYYMMDD(date) : undefined;
+          return <td data-day={dataDay} className={className} {...props} />;
+        },
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === "left") {
             return <ChevronLeftIcon className={cn("size-4", className)} {...props} />;

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -108,17 +108,27 @@ function Calendar({
         Root: ({ className, rootRef, ...props }) => {
           return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
         },
-        Day: ({ className, ...props }: any) => {
-          // Attempt to read the underlying Date from react-day-picker's props shape
-          const date: Date | undefined = (props as any)?.day?.date || (props as any)?.date;
+        Day: (
+          props: React.PropsWithChildren<
+            React.TdHTMLAttributes<HTMLTableCellElement> & {
+              day?: { date: Date };
+            }
+          >
+        ) => {
+          const { className, day, children, ...rest } = props;
+          const date: Date | undefined = day?.date;
           const formatYYYYMMDD = (d: Date) => {
             const y = d.getFullYear();
             const m = String(d.getMonth() + 1).padStart(2, "0");
-            const day = String(d.getDate()).padStart(2, "0");
-            return `${y}-${m}-${day}`;
+            const dd = String(d.getDate()).padStart(2, "0");
+            return `${y}-${m}-${dd}`;
           };
           const dataDay = date ? formatYYYYMMDD(date) : undefined;
-          return <td data-day={dataDay} className={className} {...props} />;
+          return (
+            <td data-day={dataDay} className={className} {...rest}>
+              {children}
+            </td>
+          );
         },
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === "left") {


### PR DESCRIPTION
## Summary
This PR introduces multi-select functionality for notes, allowing users to select multiple notes
and perform bulk operations (delete, archive). It also enhances the three-dot menu and adds keyboard shortcuts.

## Features
- Ctrl/Cmd + Click → select/deselect
- Double-click → enter multi-select mode
- Visual feedback + checkmark
- Bulk delete & archive with rollback on error
- Keyboard shortcuts (Ctrl+A, Esc)

###  Multi-Select for Notes
- Select multiple notes using Ctrl/Cmd + Click or by double-clicking to enter multi-select mode
- Perform bulk actions like **Delete** or **Archive**
- New visual feedback with checkmarks and highlights
- Keyboard shortcuts: Ctrl+A (select all), Esc (clear selection)

## Before
https://github.com/user-attachments/assets/9f41f147-ea14-4fd7-9c88-85b1ce51e9c0

## After
https://github.com/user-attachments/assets/9d7a4589-3ba3-48c0-b771-10d1a051b9c5






