### PR TITLE
Fix flaky checklist item test by waiting for notes API response

### DIFF
--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -44,7 +44,12 @@ test.describe("Note Management", () => {
     await expect(authenticatedPage.getByText(testItemContent)).toBeVisible();
 
     // Add a small delay to ensure all async operations complete
-    await authenticatedPage.waitForTimeout(1000);
+    await authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes`) &&
+        (resp.status() === 200 || resp.status() === 201),
+      { timeout: 15000 }
+    );
 
     const notes = await testPrisma.note.findMany({
       where: {


### PR DESCRIPTION
ref: #411
## What
Replaced `waitForTimeout(1000)` with a proper `waitForResponse` in the
`should create a note and add checklist items` test.

## Why
The test was failing intermittently because Prisma was queried before the
backend had finished persisting the checklist item. Using a fixed timeout
was unreliable and caused flakiness in CI.

## How
- Added an explicit `authenticatedPage.waitForResponse(...)` to wait for
  the `/api/boards/:id/notes` response with status 200/201.
- Removed the arbitrary `waitForTimeout`.
- Verified locally that the test now passes consistently.

With these changes, the test passed 50/50 runs locally.

## Before
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/89bda6a3-9eaf-4954-8184-0742f4babe24" />


## After
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/cba4d8cf-b124-4f10-82f5-8a16fa0c18ec" />


## Impact
- More reliable checklist creation test.
- Removes flakiness related to race conditions between UI interaction and DB writes.

### AI Disclaimer

Portions of this PR (including commit message, title, and description) were drafted with the assistance of AI (ChatGPT). All code and text changes have been reviewed and verified by the author before submission.



