### PR TITLE
Implement multi-note delete and add e2e test

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -113,39 +113,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }
   }, [user, userLoading, router]);
 
-  // Keyboard shortcuts for multi-select actions
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (selectedNoteIds.size === 0) return;
-      // Avoid when typing in inputs/textarea/contenteditable
-      const active = document.activeElement as HTMLElement | null;
-      if (active) {
-        const tag = active.tagName;
-        const isInput = tag === "INPUT" || tag === "TEXTAREA" || active.isContentEditable;
-        if (isInput) return;
-      }
-
-      // Delete selected notes on Delete key
-      if (event.key === "Delete") {
-        event.preventDefault();
-        const ids = Array.from(selectedNoteIds);
-        ids.forEach((id) => handleDeleteNote(id));
-        setSelectedNoteIds(new Set());
-        return;
-      }
-
-      // Archive selected notes on Ctrl/Cmd + Q
-      if ((event.ctrlKey || event.metaKey) && (event.key === "q" || event.key === "Q")) {
-        event.preventDefault();
-        if (boardId === "archive") return; // no archive in archive view
-        const ids = Array.from(selectedNoteIds);
-        ids.forEach((id) => handleArchiveNote(id));
-        setSelectedNoteIds(new Set());
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedNoteIds, boardId, handleArchiveNote, handleDeleteNote]);
+  
 
   // Click-outside clears selection
   useEffect(() => {
@@ -635,6 +603,40 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       duration: 4000,
     });
   };
+
+  // Keyboard shortcuts for multi-select actions
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (selectedNoteIds.size === 0) return;
+      // Avoid when typing in inputs/textarea/contenteditable
+      const active = document.activeElement as HTMLElement | null;
+      if (active) {
+        const tag = active.tagName;
+        const isInput = tag === "INPUT" || tag === "TEXTAREA" || active.isContentEditable;
+        if (isInput) return;
+      }
+
+      // Delete selected notes on Delete key
+      if (event.key === "Delete") {
+        event.preventDefault();
+        const ids = Array.from(selectedNoteIds);
+        ids.forEach((id) => handleDeleteNote(id));
+        setSelectedNoteIds(new Set());
+        return;
+      }
+
+      // Archive selected notes on Ctrl/Cmd + Q
+      if ((event.ctrlKey || event.metaKey) && (event.key === "q" || event.key === "Q")) {
+        event.preventDefault();
+        if (boardId === "archive") return; // no archive in archive view
+        const ids = Array.from(selectedNoteIds);
+        ids.forEach((id) => handleArchiveNote(id));
+        setSelectedNoteIds(new Set());
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedNoteIds, boardId, handleArchiveNote, handleDeleteNote]);
 
   const handleAddBoard = async (values: z.infer<typeof formSchema>) => {
     const { name, description } = values;

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -145,7 +145,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedNoteIds, boardId]);
+  }, [selectedNoteIds, boardId, handleArchiveNote, handleDeleteNote]);
 
   // Click-outside clears selection
   useEffect(() => {
@@ -163,7 +163,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     return () => document.removeEventListener("mousedown", handleMouseDown);
   }, [selectedNoteIds]);
 
-  const handleToggleSelect = useCallback((noteId: string, _additive: boolean) => {
+  const handleToggleSelect = useCallback((noteId: string) => {
     setSelectedNoteIds((prev) => {
       const next = new Set(prev);
       if (next.has(noteId)) {

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -113,8 +113,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }
   }, [user, userLoading, router]);
 
-  
-
   // Click-outside clears selection
   useEffect(() => {
     const handleMouseDown = (event: MouseEvent) => {

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
     if (boardId) {
       fetchBoardData();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardId]);
 
   const fetchBoardData = async () => {

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -124,7 +124,7 @@ export default function OrganizationSettingsPage() {
       fetchInvites();
       fetchSelfServeInvites();
     }
-  }, [user?.organization]);
+  }, [user?.organization?.id]);
 
   const fetchInvites = async () => {
     try {

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -351,7 +351,9 @@ export function Note({
         // Minimal top sticky shade
         "before:content-[''] before:absolute before:inset-x-0 before:top-0 before:h-1 before:opacity-20 before:pointer-events-none",
         "before:bg-gradient-to-b before:from-black/5 before:to-transparent dark:before:from-white/5",
-        isSelected ? "ring-2 ring-sky-500 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900" : "",
+        isSelected
+          ? "ring-2 ring-sky-500 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900"
+          : "",
         className
       )}
       data-testid="note-card"
@@ -370,7 +372,10 @@ export function Note({
           "SELECT",
           "LABEL",
         ];
-        if (interactiveTags.includes(target.tagName) || target.closest("button, textarea, input, a, [role='button']")) {
+        if (
+          interactiveTags.includes(target.tagName) ||
+          target.closest("button, textarea, input, a, [role='button']")
+        ) {
           return;
         }
         // Support Ctrl/Cmd additive selection; otherwise exclusive selection

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -70,7 +70,7 @@ interface NoteProps {
   style?: React.CSSProperties;
   // Selection (optional)
   isSelected?: boolean;
-  onToggleSelect?: (noteId: string, additive: boolean) => void;
+  onToggleSelect?: (noteId: string) => void;
   onSelectExclusive?: (noteId: string) => void;
 }
 
@@ -362,14 +362,21 @@ export function Note({
       onClick={(event) => {
         // Ignore clicks coming from interactive elements inside the card
         const target = event.target as HTMLElement;
-        const interactiveTags = ["BUTTON", "TEXTAREA", "INPUT", "A", "SELECT", "LABEL"] as const;
-        if (interactiveTags.includes(target.tagName as any) || target.closest("button, textarea, input, a, [role='button']")) {
+        const interactiveTags: ReadonlyArray<string> = [
+          "BUTTON",
+          "TEXTAREA",
+          "INPUT",
+          "A",
+          "SELECT",
+          "LABEL",
+        ];
+        if (interactiveTags.includes(target.tagName) || target.closest("button, textarea, input, a, [role='button']")) {
           return;
         }
         // Support Ctrl/Cmd additive selection; otherwise exclusive selection
         const additive = event.ctrlKey || event.metaKey;
         if (onToggleSelect && additive) {
-          onToggleSelect(note.id, true);
+          onToggleSelect(note.id);
         } else if (onSelectExclusive) {
           onSelectExclusive(note.id);
         }

--- a/components/ui/date-range-picker.tsx
+++ b/components/ui/date-range-picker.tsx
@@ -130,7 +130,7 @@ function DateRangePicker({
                     selected={internalStartDate || undefined}
                     onSelect={handleStartCalendarSelect}
                     modifiersClassNames={{
-                      outside: "text-gray-400 opacity-50 pointer-events-none",
+                      outside: "text-gray-400 opacity-50",
                     }}
                     classNames={{
                       day: "hover:bg-sky-500 hover:text-white transition-colors duration-200 rounded",
@@ -167,7 +167,7 @@ function DateRangePicker({
                     onSelect={handleEndCalendarSelect}
                     disabled={(date) => (internalStartDate ? date < internalStartDate : false)}
                     modifiersClassNames={{
-                      outside: "text-gray-400 opacity-50 pointer-events-none",
+                      outside: "text-gray-400 opacity-50",
                     }}
                     classNames={{
                       day: "hover:bg-sky-500 hover:text-white transition-colors duration-200 rounded",

--- a/tests/e2e/notes-multiselect.spec.ts
+++ b/tests/e2e/notes-multiselect.spec.ts
@@ -91,5 +91,3 @@ test.describe("Notes Multi-Select", () => {
     await expect(card(a2.id)).toHaveCount(0);
   });
 });
-
-

--- a/tests/e2e/notes-multiselect.spec.ts
+++ b/tests/e2e/notes-multiselect.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Notes Multi-Select", () => {
+  test("click, ctrl+click, double-click, click-outside, Delete and Ctrl+Q", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("MultiSelect Board"),
+        description: testContext.prefix("Board for multiselect tests"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // Create three notes
+    const n1 = await testPrisma.note.create({
+      data: { color: "#fff2a8", boardId: board.id, createdBy: testContext.userId },
+    });
+    const n2 = await testPrisma.note.create({
+      data: { color: "#fff2a8", boardId: board.id, createdBy: testContext.userId },
+    });
+    const n3 = await testPrisma.note.create({
+      data: { color: "#fff2a8", boardId: board.id, createdBy: testContext.userId },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    const card = (id: string) =>
+      authenticatedPage.locator(`[data-testid="note-card"][data-note-id="${id}"]`).first();
+
+    await expect(card(n1.id)).toBeVisible();
+    await expect(card(n2.id)).toBeVisible();
+    await expect(card(n3.id)).toBeVisible();
+
+    // Click selects exclusively
+    await card(n1.id).click();
+    await expect(card(n1.id)).toHaveAttribute("data-selected", "true");
+
+    // Ctrl+click adds another
+    await card(n2.id).click({ modifiers: ["Control"] });
+    await expect(card(n1.id)).toHaveAttribute("data-selected", "true");
+    await expect(card(n2.id)).toHaveAttribute("data-selected", "true");
+
+    // Double click selects exclusively
+    await card(n3.id).dblclick();
+    await expect(card(n3.id)).toHaveAttribute("data-selected", "true");
+    await expect(card(n1.id)).not.toHaveAttribute("data-selected", "true");
+    await expect(card(n2.id)).not.toHaveAttribute("data-selected", "true");
+
+    // Ctrl+click add then click outside clears
+    await card(n1.id).click({ modifiers: ["Control"] });
+    await expect(card(n1.id)).toHaveAttribute("data-selected", "true");
+    await authenticatedPage.click("body", { position: { x: 0, y: 0 } });
+    await expect(card(n1.id)).not.toHaveAttribute("data-selected", "true");
+    await expect(card(n3.id)).not.toHaveAttribute("data-selected", "true");
+
+    // Select two and press Delete to remove them
+    await card(n1.id).click();
+    await card(n2.id).click({ modifiers: ["Control"] });
+    await authenticatedPage.keyboard.press("Delete");
+
+    // Both should be deleted from UI after optimistic update
+    await expect(card(n1.id)).toHaveCount(0);
+    await expect(card(n2.id)).toHaveCount(0);
+
+    // Create two more notes to test archive shortcut
+    const a1 = await testPrisma.note.create({
+      data: { color: "#fff2a8", boardId: board.id, createdBy: testContext.userId },
+    });
+    const a2 = await testPrisma.note.create({
+      data: { color: "#fff2a8", boardId: board.id, createdBy: testContext.userId },
+    });
+
+    await authenticatedPage.reload();
+    await expect(card(a1.id)).toBeVisible();
+    await expect(card(a2.id)).toBeVisible();
+
+    await card(a1.id).click();
+    await card(a2.id).click({ modifiers: ["Control"] });
+
+    // Ctrl+Q to archive
+    await authenticatedPage.keyboard.down("Control");
+    await authenticatedPage.keyboard.press("KeyQ");
+    await authenticatedPage.keyboard.up("Control");
+
+    // Should disappear optimistically
+    await expect(card(a1.id)).toHaveCount(0);
+    await expect(card(a2.id)).toHaveCount(0);
+  });
+});
+
+


### PR DESCRIPTION
## Summary
This PR introduces multi-select functionality for notes, allowing users to select multiple notes
and perform bulk operations (delete, archive). 

## Features
- Ctrl/Cmd + Click → select/deselect
- Double-click → enter multi-select mode
- Visual feedback + checkmark
- Bulk delete & archive 
- Keyboard shortcuts (Delete button = Delete the all selected notes , Ctrl + Q= Archive the all notes)


## Before
https://github.com/user-attachments/assets/9f41f147-ea14-4fd7-9c88-85b1ce51e9c0

## After
https://github.com/user-attachments/assets/e9e7803a-5356-4b14-a3c3-b84fd57cdbe1

AI-assisted: Used Cursor for e2e test; all changes reviewed and adapted by me




