### PR TITLE
test(notes): fix flaky reorder checklist items test by waiting for note card and scoping locators

### DIFF
--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -378,17 +378,26 @@ test.describe("Note Management", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    const checkbox = authenticatedPage.locator('[data-state="unchecked"]').first();
+    // Wait for the note card to render
+    const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
+    await expect(noteCard).toBeVisible();
+
+    // Use role-based locator for checkbox inside the note
+    const checkbox = noteCard.getByRole("checkbox").first();
     await expect(checkbox).toBeVisible();
+
+    // Wait for API call while toggling
     const toggleResponse = authenticatedPage.waitForResponse(
       (resp) =>
         resp.url().includes(`/api/boards/${board.id}/notes/`) &&
         resp.request().method() === "PUT" &&
         resp.ok()
     );
+
     await checkbox.click();
     await toggleResponse;
 
+    // Verify DB state
     const updatedNote = await testPrisma.note.findUnique({
       where: { id: note.id },
       include: {

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -522,11 +522,16 @@ test.describe("Note Management", () => {
 
       await authenticatedPage.goto(`/boards/${board.id}`);
 
-      const sourceElement = authenticatedPage.getByTestId(itemA3Id);
-      const targetElement = authenticatedPage.getByTestId(itemA1Id);
+      // Ensure the note card is rendered
+      const noteCard = authenticatedPage.locator('[data-testid="note-card"]').first();
+      await expect(noteCard).toBeVisible({ timeout: 10000 });
 
-      await expect(sourceElement).toBeVisible();
-      await expect(targetElement).toBeVisible();
+      // Scope locators inside the note card
+      const sourceElement = noteCard.getByTestId(itemA3Id);
+      const targetElement = noteCard.getByTestId(itemA1Id);
+
+      await expect(sourceElement).toBeVisible({ timeout: 10000 });
+      await expect(targetElement).toBeVisible({ timeout: 10000 });
 
       const targetBox = await targetElement.boundingBox();
       if (!targetBox) throw new Error("Target element not found");
@@ -537,21 +542,18 @@ test.describe("Note Management", () => {
           resp.request().method() === "PUT" &&
           resp.ok()
       );
+
       await sourceElement.hover();
       await authenticatedPage.mouse.down();
       await targetElement.hover();
-      await targetElement.hover();
+      await authenticatedPage.waitForTimeout(100); // let DnD handlers attach
       await authenticatedPage.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 5);
       await authenticatedPage.mouse.up();
       await reorderResponse;
 
       const updatedNote = await testPrisma.note.findUnique({
         where: { id: note.id },
-        include: {
-          checklistItems: {
-            orderBy: { order: "asc" },
-          },
-        },
+        include: { checklistItems: { orderBy: { order: "asc" } } },
       });
 
       expect(updatedNote).not.toBeNull();


### PR DESCRIPTION
ref: #411 

## Summary
This PR fixes the failing test **"Note Management › Drag and Drop › should reorder checklist items within a note"**.

## What changed
- Added explicit wait for the note card (`[data-testid="note-card"]`) to ensure the checklist is rendered before locating items.
- Scoped checklist item locators inside the note card for stability.
- Added a small wait after hover to let drag-and-drop handlers attach.
- Improved timeouts for visibility checks to reduce flakiness.

## Why
The test previously timed out because `getByTestId(itemA3Id)` resolved to no element — the checklist items were not yet rendered when the assertion ran. Waiting for the note card and scoping locators aligns with Playwright best practices and makes the test more reliable.

## Before
<img width="994" height="65" alt="image" src="https://github.com/user-attachments/assets/76ab19b7-947b-43e6-9bd3-1d7186159466" />

## After
<img width="988" height="121" alt="image" src="https://github.com/user-attachments/assets/619cfe4d-33ba-4d58-b8cf-9b7de6f7832f" />

<img width="735" height="157" alt="image" src="https://github.com/user-attachments/assets/362510da-d23b-4fc6-89a7-d6fda868bde3" />


## Disclosure
This PR description and guidance were assisted by AI (ChatGPT). All changes were reviewed and verified for correctness by the author.
