### PR TITLE
fix(e2e) : failing test for note filters | select future dates

### DIFF
--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -1093,6 +1093,14 @@ test.describe("Note Management", () => {
       const futureDateButton = startCalendar.locator(
         `td[role="gridcell"][data-day="${futureDateStr}"] button:not([disabled])`
       );
+
+      // Click "next month" until date is available
+      if (!(await futureDateButton.isVisible())) {
+        for (let i = 0; i < 12; i++) {
+          await authenticatedPage.getByRole("button", { name: /next month/i }).click();
+          if (await futureDateButton.isVisible()) break;
+        }
+      }
       await expect(futureDateButton).toBeVisible();
       await futureDateButton.click();
 
@@ -1105,6 +1113,15 @@ test.describe("Note Management", () => {
       const endFutureDateButton = endCalendar.locator(
         `td[role="gridcell"][data-day="${endFutureDateStr}"] button:not([disabled])`
       );
+
+      // Click "next month" until date is available
+      if (!(await endFutureDateButton.isVisible())) {
+        for (let i = 0; i < 12; i++) {
+          await authenticatedPage.getByRole("button", { name: /next month/i }).click();
+          if (await endFutureDateButton.isVisible()) break;
+        }
+      }
+
       await expect(endFutureDateButton).toBeVisible();
       await endFutureDateButton.click();
 


### PR DESCRIPTION
### Description
- The original code tried to select dates directly without checking if they were visible in the current calendar month. When the target date (7 days ahead) fell in the next month, the date button didn't exist, causing the test to fail.
- `should allow selecting future dates in date range picker` 



### Before:

https://github.com/antiwork/gumboard/actions/runs/18068540987/job/51414898974

### After: 
<img width="807" height="205" alt="image" src="https://github.com/user-attachments/assets/86a275ed-7df0-4fbd-b896-d033b25fc892" />


### AI usage
used gpt to investigate

### Test 
all good
