### PR TITLE
fix: handle empty card in public board

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -226,7 +226,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
 
   // Get filtered and sorted notes for display
   const filteredNotes = useMemo(
-    () => filterAndSortNotes(notes, debouncedSearchTerm, dateRange, selectedAuthor, user),
+    () => filterAndSortNotes(notes, debouncedSearchTerm, dateRange, selectedAuthor, user, false),
     [notes, debouncedSearchTerm, dateRange, selectedAuthor, user]
   );
 

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -89,7 +89,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
   const uniqueAuthors = useMemo(() => getUniqueAuthors(notes), [notes]);
 
   const filteredNotes = useMemo(
-    () => filterAndSortNotes(notes, searchTerm, dateRange, selectedAuthor, null),
+    () => filterAndSortNotes(notes, searchTerm, dateRange, selectedAuthor, null, true),
     [notes, searchTerm, dateRange, selectedAuthor]
   );
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -127,7 +127,8 @@ export function filterAndSortNotes(
   searchTerm: string,
   dateRange: { startDate: Date | null; endDate: Date | null },
   authorId: string | null,
-  currentUser?: { id: string } | null
+  currentUser?: { id: string } | null,
+  hideEmptyChecklists?: boolean
 ): Note[] {
   let filteredNotes = notes;
 
@@ -164,6 +165,12 @@ export function filterAndSortNotes(
       }
       return true;
     });
+  }
+
+  if (hideEmptyChecklists) {
+    filteredNotes = filteredNotes.filter(
+      (note) => note.checklistItems && note.checklistItems.length > 0
+    );
   }
 
   filteredNotes.sort((a, b) => {

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -12,7 +12,7 @@ test.describe("Board Management", () => {
 
     await authenticatedPage.click('button:has-text("Add Board")');
     await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
-    await authenticatedPage.fill('input[placeholder*="board description"]', boardDescription);
+    await authenticatedPage.fill('textarea[placeholder*="board description"]', boardDescription);
     const responsePromise = authenticatedPage.waitForResponse(
       (resp) => resp.url().includes("/api/boards") && resp.status() === 201
     );


### PR DESCRIPTION
currently in public board, the empty checklist (card) is being shown. empty card can be hidden (filter out) as it doesnt add any value in read mode (public)

## before
<img width="1512" height="982" alt="Screenshot 2025-09-30 at 10 11 18 AM" src="https://github.com/user-attachments/assets/a1722177-5061-4b6d-9e8d-336619980670" />

## after
<img width="1512" height="982" alt="Screenshot 2025-09-30 at 10 10 23 AM" src="https://github.com/user-attachments/assets/56b07e68-9a97-4201-afe5-61907f3463d5" />

## test
<img width="1512" height="836" alt="Screenshot 2025-09-30 at 10 08 52 AM" src="https://github.com/user-attachments/assets/b3c64152-de1c-48a4-bd9d-02e9082814eb" />

## use of ai
none