### PR TITLE
fix(test): future date selection test fails on month end

### DIFF
--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -1093,6 +1093,15 @@ test.describe("Note Management", () => {
       const futureDateButton = startCalendar.locator(
         `td[role="gridcell"][data-day="${futureDateStr}"] button:not([disabled])`
       );
+
+      // Click "next month" until date is available
+      if (!(await futureDateButton.isVisible())) {
+        for (let i = 0; i < 12; i++) {
+          await authenticatedPage.getByRole("button", { name: /next month/i }).click();
+          if (await futureDateButton.isVisible()) break;
+        }
+      }
+
       await expect(futureDateButton).toBeVisible();
       await futureDateButton.click();
 
@@ -1105,6 +1114,13 @@ test.describe("Note Management", () => {
       const endFutureDateButton = endCalendar.locator(
         `td[role="gridcell"][data-day="${endFutureDateStr}"] button:not([disabled])`
       );
+      // Click "next month" until date is available
+      if (!(await endFutureDateButton.isVisible())) {
+        for (let i = 0; i < 12; i++) {
+          await authenticatedPage.getByRole("button", { name: /next month/i }).click();
+          if (await endFutureDateButton.isVisible()) break;
+        }
+      }
       await expect(endFutureDateButton).toBeVisible();
       await endFutureDateButton.click();
 
@@ -1255,7 +1271,7 @@ test.describe("Note Management", () => {
       },
     });
 
-    const originalNote = await testPrisma.note.create({
+    await testPrisma.note.create({
       data: {
         color: "#cde4ff",
         boardId: board.id,


### PR DESCRIPTION
### Description

This PR fixes the failing future date selection test that occurs at month-end when future dates are unavailable. The test now correctly navigates to the next month to select a valid date.

The implementation logic is taken from #823.