### PR TITLE
Board level sharing

### DIFF
--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         id: true,
         isPublic: true,
         organizationId: true,
+        createdBy: true, // Added for authorization check
         notes: {
           where: {
             deletedAt: null, // Only include non-deleted notes
@@ -75,7 +76,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Check if user has explicit sharing permissions for this board
+    // Board creators automatically have access to their own boards
+    // Check if user has explicit sharing permissions for this board OR is the creator
     const boardShare = await db.boardShare.findFirst({
       where: {
         boardId: boardId,
@@ -83,7 +85,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       },
     });
 
-    if (!boardShare) {
+    if (!boardShare && board.createdBy !== session.user.id) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
@@ -161,6 +163,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         id: true,
         name: true,
         organizationId: true,
+        createdBy: true, // Added for authorization check
         sendSlackUpdates: true,
       },
     });
@@ -181,7 +184,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Check if user has explicit sharing permissions for this board
+    // Board creators automatically have access to their own boards
+    // Check if user has explicit sharing permissions for this board OR is the creator
     const boardShare = await db.boardShare.findFirst({
       where: {
         boardId: boardId,
@@ -189,7 +193,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       },
     });
 
-    if (!boardShare) {
+    if (!boardShare && board.createdBy !== session.user.id) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 

--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -63,18 +63,27 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await db.user.findUnique({
-      where: { id: session.user.id },
-      select: {
-        organizationId: true,
+    // Check if user is in the organization (required for board sharing)
+    const userInOrg = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
       },
     });
 
-    if (!user?.organizationId) {
-      return NextResponse.json({ error: "No organization found" }, { status: 403 });
+    if (!userInOrg) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    if (board.organizationId !== user.organizationId) {
+    // Check if user has explicit sharing permissions for this board
+    const boardShare = await db.boardShare.findFirst({
+      where: {
+        boardId: boardId,
+        userId: session.user.id,
+      },
+    });
+
+    if (!boardShare) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
@@ -115,9 +124,21 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     }
     const { color, checklistItems } = validatedBody;
 
-    // Verify user has access to this board (same organization)
+    // Verify user has access to this board (either through organization membership or explicit board share)
     const user = await db.user.findUnique({
-      where: { id: session.user.id },
+      where: {
+        id: session.user.id,
+        OR: [
+          { organizationId: { not: null } },
+          {
+            boardShares: {
+              some: {
+                boardId: boardId,
+              },
+            },
+          },
+        ],
+      },
       select: {
         organizationId: true,
         organization: {
@@ -130,8 +151,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       },
     });
 
-    if (!user?.organizationId) {
-      return NextResponse.json({ error: "No organization found" }, { status: 403 });
+    if (!user) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
     const board = await db.board.findUnique({
@@ -148,7 +169,27 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
 
-    if (board.organizationId !== user.organizationId) {
+    // Check if user is in the organization (required for board sharing)
+    const userInOrg = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+    });
+
+    if (!userInOrg) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Check if user has explicit sharing permissions for this board
+    const boardShare = await db.boardShare.findFirst({
+      where: {
+        boardId: boardId,
+        userId: session.user.id,
+      },
+    });
+
+    if (!boardShare) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 

--- a/app/api/boards/[id]/notes/route.ts
+++ b/app/api/boards/[id]/notes/route.ts
@@ -23,10 +23,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         id: true,
         isPublic: true,
         organizationId: true,
-        createdBy: true, // Added for authorization check
+        createdBy: true,
         notes: {
           where: {
-            deletedAt: null, // Only include non-deleted notes
+            deletedAt: null,
             archivedAt: null,
           },
           select: {
@@ -64,7 +64,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Check if user is in the organization (required for board sharing)
     const userInOrg = await db.user.findFirst({
       where: {
         id: session.user.id,
@@ -76,8 +75,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Board creators automatically have access to their own boards
-    // Check if user has explicit sharing permissions for this board OR is the creator
     const boardShare = await db.boardShare.findFirst({
       where: {
         boardId: boardId,
@@ -163,7 +160,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         id: true,
         name: true,
         organizationId: true,
-        createdBy: true, // Added for authorization check
+        createdBy: true,
         sendSlackUpdates: true,
       },
     });
@@ -172,7 +169,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Board not found" }, { status: 404 });
     }
 
-    // Check if user is in the organization (required for board sharing)
     const userInOrg = await db.user.findFirst({
       where: {
         id: session.user.id,
@@ -184,8 +180,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Board creators automatically have access to their own boards
-    // Check if user has explicit sharing permissions for this board OR is the creator
     const boardShare = await db.boardShare.findFirst({
       where: {
         boardId: boardId,

--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -47,8 +47,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Board creators automatically have access to their own boards
-    // Check if user has explicit sharing permissions for this board OR is the creator
     const boardShare = await db.boardShare.findFirst({
       where: {
         boardId: boardId,

--- a/app/api/boards/[id]/share/route.ts
+++ b/app/api/boards/[id]/share/route.ts
@@ -66,7 +66,7 @@ async function updateOrganizationSharingStatus(organizationId: string) {
   }
 }
 
-// GET /api/boards/[id]/share - Get sharing status for a board
+// Get sharing status for a board
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const session = await auth();
@@ -142,7 +142,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   }
 }
 
-// PUT /api/boards/[id]/share - Update sharing for specific users on this board
+// Update sharing for specific users on this board
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const session = await auth();

--- a/app/api/boards/[id]/share/route.ts
+++ b/app/api/boards/[id]/share/route.ts
@@ -132,7 +132,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       isShared: sharedUserIds.has(member.id),
     }));
 
-    return NextResponse.json({ members: membersWithSharing });
+    return NextResponse.json({
+      members: membersWithSharing,
+      boardCreator: board.createdBy
+    });
   } catch (error) {
     console.error("Error fetching board sharing:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/boards/[id]/share/route.ts
+++ b/app/api/boards/[id]/share/route.ts
@@ -23,7 +23,7 @@ async function updateOrganizationSharingStatus(organizationId: string) {
     // Get current board shares for all boards in the organization
     const allBoardShares = await db.boardShare.findMany({
       where: {
-        boardId: { in: boards.map(b => b.id) },
+        boardId: { in: boards.map((b) => b.id) },
       },
       select: {
         boardId: true,
@@ -33,7 +33,7 @@ async function updateOrganizationSharingStatus(organizationId: string) {
 
     // Group shares by user
     const sharesByUser = new Map<string, Set<string>>();
-    allBoardShares.forEach(share => {
+    allBoardShares.forEach((share) => {
       if (!sharesByUser.has(share.userId)) {
         sharesByUser.set(share.userId, new Set());
       }
@@ -47,13 +47,11 @@ async function updateOrganizationSharingStatus(organizationId: string) {
 
       // If user should share all boards but doesn't have shares for all boards, add them
       if (shouldShareAllBoards) {
-        const missingBoardIds = boards
-          .map(b => b.id)
-          .filter(id => !sharedBoardIds.has(id));
+        const missingBoardIds = boards.map((b) => b.id).filter((id) => !sharedBoardIds.has(id));
 
         if (missingBoardIds.length > 0) {
           await db.boardShare.createMany({
-            data: missingBoardIds.map(boardId => ({
+            data: missingBoardIds.map((boardId) => ({
               boardId,
               userId: user.id,
             })),
@@ -121,10 +119,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       select: { userId: true },
     });
 
-    const sharedUserIds = new Set(boardShares.map(share => share.userId));
+    const sharedUserIds = new Set(boardShares.map((share) => share.userId));
 
     // Combine member data with sharing status
-    const membersWithSharing = organizationMembers.map(member => ({
+    const membersWithSharing = organizationMembers.map((member) => ({
       id: member.id,
       name: member.name,
       email: member.email,
@@ -134,7 +132,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     return NextResponse.json({
       members: membersWithSharing,
-      boardCreator: board.createdBy
+      boardCreator: board.createdBy,
     });
   } catch (error) {
     console.error("Error fetching board sharing:", error);
@@ -202,13 +200,16 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     });
 
     if (validUsers.length !== userIds.length) {
-      return NextResponse.json({ error: "Some users are not in the organization" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Some users are not in the organization" },
+        { status: 400 }
+      );
     }
 
     // Update board shares - delete existing and create new ones
     await db.$transaction([
       db.boardShare.deleteMany({ where: { boardId } }),
-      ...userIds.map(userId =>
+      ...userIds.map((userId) =>
         db.boardShare.create({
           data: {
             boardId,

--- a/app/api/boards/[id]/share/route.ts
+++ b/app/api/boards/[id]/share/route.ts
@@ -1,0 +1,232 @@
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// Helper function to update organization-level sharing status when board sharing changes
+async function updateOrganizationSharingStatus(organizationId: string) {
+  try {
+    // Get all boards in the organization
+    const boards = await db.board.findMany({
+      where: { organizationId },
+      select: { id: true },
+    });
+
+    if (boards.length === 0) return;
+
+    // Get all users in the organization
+    const users = await db.user.findMany({
+      where: { organizationId },
+      select: { id: true },
+    });
+
+    // Get current board shares for all boards in the organization
+    const allBoardShares = await db.boardShare.findMany({
+      where: {
+        boardId: { in: boards.map(b => b.id) },
+      },
+      select: {
+        boardId: true,
+        userId: true,
+      },
+    });
+
+    // Group shares by user
+    const sharesByUser = new Map<string, Set<string>>();
+    allBoardShares.forEach(share => {
+      if (!sharesByUser.has(share.userId)) {
+        sharesByUser.set(share.userId, new Set());
+      }
+      sharesByUser.get(share.userId)!.add(share.boardId);
+    });
+
+    // For each user, check if they should have "share all boards" status
+    for (const user of users) {
+      const sharedBoardIds = sharesByUser.get(user.id) || new Set();
+      const shouldShareAllBoards = boards.length > 0 && sharedBoardIds.size === boards.length;
+
+      // If user should share all boards but doesn't have shares for all boards, add them
+      if (shouldShareAllBoards) {
+        const missingBoardIds = boards
+          .map(b => b.id)
+          .filter(id => !sharedBoardIds.has(id));
+
+        if (missingBoardIds.length > 0) {
+          await db.boardShare.createMany({
+            data: missingBoardIds.map(boardId => ({
+              boardId,
+              userId: user.id,
+            })),
+          });
+        }
+      }
+    }
+  } catch (error) {
+    console.error("Error updating organization sharing status:", error);
+  }
+}
+
+// GET /api/boards/[id]/share - Get sharing status for a board
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const boardId = (await params).id;
+
+    // Check if board exists and user has access
+    const board = await db.board.findUnique({
+      where: { id: boardId },
+      include: { organization: true },
+    });
+
+    if (!board) {
+      return NextResponse.json({ error: "Board not found" }, { status: 404 });
+    }
+
+    // Check if user is member of the organization and get admin status
+    const currentUser = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    });
+
+    if (!currentUser) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Get all organization members
+    const organizationMembers = await db.user.findMany({
+      where: { organizationId: board.organizationId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        isAdmin: true,
+      },
+      orderBy: { name: "asc" },
+    });
+
+    // Get current board shares for this board
+    const boardShares = await db.boardShare.findMany({
+      where: { boardId },
+      select: { userId: true },
+    });
+
+    const sharedUserIds = new Set(boardShares.map(share => share.userId));
+
+    // Combine member data with sharing status
+    const membersWithSharing = organizationMembers.map(member => ({
+      id: member.id,
+      name: member.name,
+      email: member.email,
+      isAdmin: member.isAdmin,
+      isShared: sharedUserIds.has(member.id),
+    }));
+
+    return NextResponse.json({ members: membersWithSharing });
+  } catch (error) {
+    console.error("Error fetching board sharing:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// PUT /api/boards/[id]/share - Update sharing for specific users on this board
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const boardId = (await params).id;
+    const body = await request.json();
+
+    const schema = z.object({
+      userIds: z.array(z.string()),
+    });
+
+    const validatedBody = schema.parse(body);
+    const { userIds } = validatedBody;
+
+    // Check if board exists and user has access
+    const board = await db.board.findUnique({
+      where: { id: boardId },
+      include: { organization: true },
+    });
+
+    if (!board) {
+      return NextResponse.json({ error: "Board not found" }, { status: 404 });
+    }
+
+    // Check if user is member of the organization and get admin status
+    const currentUser = await db.user.findFirst({
+      where: {
+        id: session.user.id,
+        organizationId: board.organizationId,
+      },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    });
+
+    if (!currentUser) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Only admins can update board sharing
+    if (!currentUser.isAdmin) {
+      return NextResponse.json({ error: "Only admins can update board sharing" }, { status: 403 });
+    }
+
+    // Validate that all userIds are in the same organization
+    const validUsers = await db.user.findMany({
+      where: {
+        id: { in: userIds },
+        organizationId: board.organizationId,
+      },
+      select: { id: true },
+    });
+
+    if (validUsers.length !== userIds.length) {
+      return NextResponse.json({ error: "Some users are not in the organization" }, { status: 400 });
+    }
+
+    // Update board shares - delete existing and create new ones
+    await db.$transaction([
+      db.boardShare.deleteMany({ where: { boardId } }),
+      ...userIds.map(userId =>
+        db.boardShare.create({
+          data: {
+            boardId,
+            userId,
+          },
+        })
+      ),
+    ]);
+
+    // Check if this affects any user's "share all boards" status and update organization settings
+    await updateOrganizationSharingStatus(board.organizationId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation failed", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating board sharing:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
       return NextResponse.json({ error: "No organization found" }, { status: 404 });
     }
 
-    // Get boards the user has access to (public boards or explicitly shared with the user)
+    // Get boards the user has access to (public boards, explicitly shared boards, or boards created by the user)
     const boards = await db.board.findMany({
       where: {
         OR: [
@@ -35,6 +35,7 @@ export async function GET() {
               },
             },
           },
+          { createdBy: session.user.id }, // Boards created by the user
         ],
       },
       select: {
@@ -166,6 +167,14 @@ export async function POST(request: NextRequest) {
             },
           },
         },
+      },
+    });
+
+    // Automatically create a board sharing record for the creator
+    await db.boardShare.create({
+      data: {
+        boardId: board.id,
+        userId: session.user.id,
       },
     });
 

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -23,9 +23,20 @@ export async function GET() {
       return NextResponse.json({ error: "No organization found" }, { status: 404 });
     }
 
-    // Get all boards for the organization
+    // Get boards the user has access to (public boards or explicitly shared with the user)
     const boards = await db.board.findMany({
-      where: { organizationId: user.organizationId },
+      where: {
+        OR: [
+          { isPublic: true },
+          {
+            shares: {
+              some: {
+                userId: session.user.id,
+              },
+            },
+          },
+        ],
+      },
       select: {
         id: true,
         name: true,
@@ -34,6 +45,12 @@ export async function GET() {
         createdBy: true,
         createdAt: true,
         updatedAt: true,
+        organization: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
         _count: {
           select: {
             notes: {

--- a/app/api/organization/share/route.ts
+++ b/app/api/organization/share/route.ts
@@ -1,0 +1,244 @@
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// Helper function to update board-level sharing status when organization sharing changes
+async function updateBoardSharingStatus(orgId: string) {
+  try {
+    // Get all boards in the organization
+    const boards = await db.board.findMany({
+      where: { organizationId: orgId },
+      select: { id: true },
+    });
+
+    if (boards.length === 0) return;
+
+    // For each user that has "share all boards" enabled, ensure they have shares for all boards
+    // This is handled by the existing logic in the main function, but we could add additional logic here if needed
+
+    // If a user has specific board shares that don't match their "share all boards" status,
+    // we might need to adjust, but this is complex and might be better handled in the UI layer
+  } catch (error) {
+    console.error("Error updating board sharing status:", error);
+  }
+}
+
+// GET /api/organization/share - Get sharing status for all organization members across all boards
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Get user with organization
+    const user = await db.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        organizationId: true,
+        isAdmin: true,
+      },
+    });
+
+    if (!user?.organizationId) {
+      return NextResponse.json({ error: "No organization found" }, { status: 404 });
+    }
+
+    // Only admins can view organization sharing
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Only admins can view organization sharing" }, { status: 403 });
+    }
+
+    // Get all organization members
+    const organizationMembers = await db.user.findMany({
+      where: { organizationId: user.organizationId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        isAdmin: true,
+      },
+      orderBy: { name: "asc" },
+    });
+
+    // Get all boards in the organization
+    const boards = await db.board.findMany({
+      where: { organizationId: user.organizationId },
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: { name: "asc" },
+    });
+
+    // Get all board shares for this organization
+    const boardShares = await db.boardShare.findMany({
+      where: {
+        board: {
+          organizationId: user.organizationId,
+        },
+      },
+      select: {
+        boardId: true,
+        userId: true,
+      },
+    });
+
+    // Create a map of board shares by user
+    const sharesByUser = new Map<string, Set<string>>();
+    boardShares.forEach(share => {
+      if (!sharesByUser.has(share.userId)) {
+        sharesByUser.set(share.userId, new Set());
+      }
+      sharesByUser.get(share.userId)!.add(share.boardId);
+    });
+
+    // For each member, determine if they have all boards shared
+    const membersWithSharingStatus = organizationMembers.map(member => {
+      const sharedBoardIds = sharesByUser.get(member.id) || new Set();
+      const allBoardsShared = boards.length > 0 && sharedBoardIds.size === boards.length;
+
+      return {
+        id: member.id,
+        name: member.name,
+        email: member.email,
+        isAdmin: member.isAdmin,
+        shareAllBoards: allBoardsShared,
+        sharedBoardIds: Array.from(sharedBoardIds),
+        totalBoards: boards.length,
+      };
+    });
+
+    return NextResponse.json({
+      members: membersWithSharingStatus,
+      boards: boards.map(board => ({ id: board.id, name: board.name })),
+    });
+  } catch (error) {
+    console.error("Error fetching organization sharing:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// PUT /api/organization/share - Update sharing for specific users across all boards
+export async function PUT(request: NextRequest) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const schema = z.object({
+      userSharing: z.array(z.object({
+        userId: z.string(),
+        shareAllBoards: z.boolean(),
+        sharedBoardIds: z.array(z.string()).optional(),
+      })),
+    });
+
+    const validatedBody = schema.parse(body);
+    const { userSharing } = validatedBody;
+
+    // Get user with organization
+    const user = await db.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        organizationId: true,
+        isAdmin: true,
+      },
+    });
+
+    if (!user?.organizationId) {
+      return NextResponse.json({ error: "No organization found" }, { status: 404 });
+    }
+
+    const organizationId = user.organizationId;
+
+    // Only admins can update organization sharing
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Only admins can update organization sharing" }, { status: 403 });
+    }
+
+    // Get all boards in the organization
+    const boards = await db.board.findMany({
+      where: { organizationId },
+      select: { id: true },
+    });
+
+    const boardIds = boards.map(board => board.id);
+
+    // Validate that all userIds are in the same organization
+    const validUsers = await db.user.findMany({
+      where: {
+        id: { in: userSharing.map(us => us.userId) },
+        organizationId,
+      },
+      select: { id: true },
+    });
+
+    if (validUsers.length !== userSharing.length) {
+      return NextResponse.json({ error: "Some users are not in the organization" }, { status: 400 });
+    }
+
+    // Update sharing for each user
+    for (const userShare of userSharing) {
+      if (userShare.shareAllBoards) {
+        // Share all boards with this user
+        await db.boardShare.deleteMany({
+          where: {
+            boardId: { in: boardIds },
+            userId: userShare.userId,
+          },
+        });
+
+        await db.boardShare.createMany({
+          data: boardIds.map(boardId => ({
+            boardId,
+            userId: userShare.userId,
+          })),
+        });
+      } else if (userShare.sharedBoardIds && userShare.sharedBoardIds.length > 0) {
+        // Share specific boards with this user
+        await db.boardShare.deleteMany({
+          where: {
+            boardId: { in: boardIds },
+            userId: userShare.userId,
+          },
+        });
+
+        await db.boardShare.createMany({
+          data: userShare.sharedBoardIds.map(boardId => ({
+            boardId,
+            userId: userShare.userId,
+          })),
+        });
+      } else {
+        // Share no boards with this user
+        await db.boardShare.deleteMany({
+          where: {
+            boardId: { in: boardIds },
+            userId: userShare.userId,
+          },
+        });
+      }
+    }
+
+    // Check if this affects any user's board-specific sharing and update accordingly
+    await updateBoardSharingStatus(organizationId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation failed", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating organization sharing:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/organization/share/route.ts
+++ b/app/api/organization/share/route.ts
@@ -14,17 +14,12 @@ async function updateBoardSharingStatus(orgId: string) {
 
     if (boards.length === 0) return;
 
-    // For each user that has "share all boards" enabled, ensure they have shares for all boards
-    // This is handled by the existing logic in the main function, but we could add additional logic here if needed
-
-    // If a user has specific board shares that don't match their "share all boards" status,
-    // we might need to adjust, but this is complex and might be better handled in the UI layer
   } catch (error) {
     console.error("Error updating board sharing status:", error);
   }
 }
 
-// GET /api/organization/share - Get sharing status for all organization members across all boards
+// Get sharing status for all organization members across all boards
 export async function GET() {
   try {
     const session = await auth();
@@ -121,7 +116,7 @@ export async function GET() {
   }
 }
 
-// PUT /api/organization/share - Update sharing for specific users across all boards
+// Update sharing for specific users across all boards
 export async function PUT(request: NextRequest) {
   try {
     const session = await auth();

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -17,7 +17,6 @@ import {
   StickyNote,
   Plus,
   Users,
-  Eye,
 } from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
@@ -668,41 +667,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }
   };
 
-  const handleUpdateBoardSharing = async (userIds: string[]) => {
-    if (!boardId || boardId === "all-notes" || boardId === "archive") return;
-
-    setUpdatingSharing("bulk");
-    try {
-      const response = await fetch(`/api/boards/${boardId}/share`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ userIds }),
-      });
-
-      if (response.ok) {
-        await fetchBoardSharing();
-        setBoardSharingDialog(false);
-      } else {
-        const errorData = await response.json();
-        setErrorDialog({
-          open: true,
-          title: "Failed to update board sharing",
-          description: errorData.error || "Failed to update board sharing",
-        });
-      }
-    } catch (error) {
-      console.error("Error updating board sharing:", error);
-      setErrorDialog({
-        open: true,
-        title: "Failed to update board sharing",
-        description: "Failed to update board sharing",
-      });
-    } finally {
-      setUpdatingSharing(null);
-    }
-  };
 
   const handleToggleMemberSharing = async (memberId: string, isShared: boolean) => {
     if (!boardId || boardId === "all-notes" || boardId === "archive") return;

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -102,7 +102,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   });
   const [copiedPublicUrl, setCopiedPublicUrl] = useState(false);
   const [deleteConfirmDialog, setDeleteConfirmDialog] = useState(false);
-  const [boardSharing, setBoardSharing] = useState<{ id: string; name: string; email: string; isShared: boolean }[]>([]);
+  const [boardSharing, setBoardSharing] = useState<
+    { id: string; name: string; email: string; isShared: boolean }[]
+  >([]);
   const [boardCreator, setBoardCreator] = useState<string | null>(null);
   const [memberSearchTerm, setMemberSearchTerm] = useState("");
   const [updatingSharing, setUpdatingSharing] = useState<string | null>(null);
@@ -667,19 +669,18 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }
   };
 
-
   const handleToggleMemberSharing = async (memberId: string, isShared: boolean) => {
     if (!boardId || boardId === "all-notes" || boardId === "archive") return;
 
     setUpdatingSharing(memberId);
     try {
       const currentSharedIds = boardSharing
-        .filter(member => member.isShared)
-        .map(member => member.id);
+        .filter((member) => member.isShared)
+        .map((member) => member.id);
 
       const newSharedIds = isShared
         ? [...currentSharedIds, memberId]
-        : currentSharedIds.filter(id => id !== memberId);
+        : currentSharedIds.filter((id) => id !== memberId);
 
       // Use individual update function that doesn't close the dialog
       await handleUpdateBoardSharingIndividual(newSharedIds);
@@ -1312,7 +1313,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {boardSharing
-                    .filter(member => member.isShared)
+                    .filter((member) => member.isShared)
                     .slice(0, 3)
                     .map((member) => (
                       <span
@@ -1322,9 +1323,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                         {member.name || member.email}
                       </span>
                     ))}
-                  {boardSharing.filter(member => member.isShared).length > 3 && (
+                  {boardSharing.filter((member) => member.isShared).length > 3 && (
                     <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200">
-                      +{boardSharing.filter(member => member.isShared).length - 3} more
+                      +{boardSharing.filter((member) => member.isShared).length - 3} more
                     </span>
                   )}
                 </div>
@@ -1360,7 +1361,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               Share &quot;{board?.name}&quot; with team members
             </DialogTitle>
             <DialogDescription className="text-muted-foreground dark:text-zinc-400">
-              Select which team members should have access to this board. Only selected members will be able to view and edit notes in this board.
+              Select which team members should have access to this board. Only selected members will
+              be able to view and edit notes in this board.
             </DialogDescription>
           </DialogHeader>
 
@@ -1380,9 +1382,12 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           {/* Member List */}
           <div className="space-y-3 max-h-96 overflow-y-auto">
             {boardSharing
-              .filter(member =>
-                memberSearchTerm === "" ||
-                (member.name || member.email).toLowerCase().includes(memberSearchTerm.toLowerCase())
+              .filter(
+                (member) =>
+                  memberSearchTerm === "" ||
+                  (member.name || member.email)
+                    .toLowerCase()
+                    .includes(memberSearchTerm.toLowerCase())
               )
               .map((member) => {
                 const isCreator = boardCreator === member.id;
@@ -1392,9 +1397,13 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                     className="flex items-center justify-between p-3 bg-zinc-50 dark:bg-zinc-800 rounded-lg"
                   >
                     <div className="flex items-center space-x-3">
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-medium ${
-                        isCreator ? "bg-purple-500 dark:bg-purple-600" : "bg-blue-500 dark:bg-zinc-700"
-                      }`}>
+                      <div
+                        className={`w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-medium ${
+                          isCreator
+                            ? "bg-purple-500 dark:bg-purple-600"
+                            : "bg-blue-500 dark:bg-zinc-700"
+                        }`}
+                      >
                         {(member.name || member.email).charAt(0).toUpperCase()}
                       </div>
                       <div>
@@ -1418,7 +1427,9 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
                         <>
                           <Switch
                             checked={member.isShared}
-                            onCheckedChange={(checked) => handleToggleMemberSharing(member.id, checked)}
+                            onCheckedChange={(checked) =>
+                              handleToggleMemberSharing(member.id, checked)
+                            }
                             disabled={updatingSharing === member.id || updatingSharing === "bulk"}
                             className="data-[state=checked]:bg-green-600"
                           />
@@ -1436,7 +1447,11 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           {/* Summary */}
           <div className="flex justify-between items-center pt-4 border-t border-zinc-200 dark:border-zinc-800">
             <div className="text-sm text-zinc-600 dark:text-zinc-400">
-              {boardSharing.filter(member => member.isShared || member.id === boardCreator).length} of {boardSharing.length} members have access
+              {
+                boardSharing.filter((member) => member.isShared || member.id === boardCreator)
+                  .length
+              }{" "}
+              of {boardSharing.length} members have access
             </div>
             <Button
               variant="outline"

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -16,6 +16,8 @@ import {
   XIcon,
   StickyNote,
   Plus,
+  Users,
+  Eye,
 } from "lucide-react";
 import Link from "next/link";
 import { BetaBadge } from "@/components/ui/beta-badge";
@@ -101,6 +103,10 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   });
   const [copiedPublicUrl, setCopiedPublicUrl] = useState(false);
   const [deleteConfirmDialog, setDeleteConfirmDialog] = useState(false);
+  const [boardSharing, setBoardSharing] = useState<{ id: string; name: string; email: string; isShared: boolean }[]>([]);
+  const [memberSearchTerm, setMemberSearchTerm] = useState("");
+  const [updatingSharing, setUpdatingSharing] = useState<string | null>(null);
+  const [boardSharingDialog, setBoardSharingDialog] = useState(false);
   const boardRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -211,6 +217,12 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardId]);
+
+  useEffect(() => {
+    if (boardSettingsDialog && boardId && boardId !== "all-notes" && boardId !== "archive") {
+      fetchBoardSharing();
+    }
+  }, [boardSettingsDialog, boardId]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -637,6 +649,77 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
       setTimeout(() => setCopiedPublicUrl(false), 2000);
     } catch (error) {
       console.error("Failed to copy URL:", error);
+    }
+  };
+
+  const fetchBoardSharing = async () => {
+    if (!boardId || boardId === "all-notes" || boardId === "archive") return;
+
+    try {
+      const response = await fetch(`/api/boards/${boardId}/share`);
+      if (response.ok) {
+        const data = await response.json();
+        setBoardSharing(data.members || []);
+      }
+    } catch (error) {
+      console.error("Error fetching board sharing:", error);
+    }
+  };
+
+  const handleUpdateBoardSharing = async (userIds: string[]) => {
+    if (!boardId || boardId === "all-notes" || boardId === "archive") return;
+
+    setUpdatingSharing("bulk");
+    try {
+      const response = await fetch(`/api/boards/${boardId}/share`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ userIds }),
+      });
+
+      if (response.ok) {
+        await fetchBoardSharing();
+        setBoardSharingDialog(false);
+      } else {
+        const errorData = await response.json();
+        setErrorDialog({
+          open: true,
+          title: "Failed to update board sharing",
+          description: errorData.error || "Failed to update board sharing",
+        });
+      }
+    } catch (error) {
+      console.error("Error updating board sharing:", error);
+      setErrorDialog({
+        open: true,
+        title: "Failed to update board sharing",
+        description: "Failed to update board sharing",
+      });
+    } finally {
+      setUpdatingSharing(null);
+    }
+  };
+
+  const handleToggleMemberSharing = async (memberId: string, isShared: boolean) => {
+    if (!boardId || boardId === "all-notes" || boardId === "archive") return;
+
+    setUpdatingSharing(memberId);
+    try {
+      const currentSharedIds = boardSharing
+        .filter(member => member.isShared)
+        .map(member => member.id);
+
+      const newSharedIds = isShared
+        ? [...currentSharedIds, memberId]
+        : currentSharedIds.filter(id => id !== memberId);
+
+      await handleUpdateBoardSharing(newSharedIds);
+    } catch (error) {
+      console.error("Error toggling member sharing:", error);
+    } finally {
+      setUpdatingSharing(null);
     }
   };
 
@@ -1196,6 +1279,56 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
             </p>
           </div>
 
+          {/* Board Sharing Section */}
+          <div className="space-y-4 pt-4 border-t border-zinc-200 dark:border-zinc-800">
+            <div>
+              <div className="flex items-center justify-between">
+                <label className="block text-sm font-medium text-foreground dark:text-zinc-200 mb-1">
+                  Share with team members
+                </label>
+                <Button
+                  onClick={() => setBoardSharingDialog(true)}
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center space-x-2"
+                >
+                  <Users className="w-4 h-4" />
+                  <span>Manage Sharing</span>
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground dark:text-zinc-400 mt-1">
+                Control which team members can access this board
+              </p>
+            </div>
+
+            {/* Quick preview of shared members */}
+            {boardSharing.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground dark:text-zinc-200">
+                  Currently shared with:
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {boardSharing
+                    .filter(member => member.isShared)
+                    .slice(0, 3)
+                    .map((member) => (
+                      <span
+                        key={member.id}
+                        className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+                      >
+                        {member.name || member.email}
+                      </span>
+                    ))}
+                  {boardSharing.filter(member => member.isShared).length > 3 && (
+                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+                      +{boardSharing.filter(member => member.isShared).length - 3} more
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
           <AlertDialogFooter className="flex !flex-row justify-start md:justify-between">
             <Button
               onClick={() => setDeleteConfirmDialog(true)}
@@ -1215,6 +1348,85 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Board Sharing Dialog */}
+      <Dialog open={boardSharingDialog} onOpenChange={setBoardSharingDialog}>
+        <DialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-foreground dark:text-zinc-100">
+              Share &quot;{board?.name}&quot; with team members
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground dark:text-zinc-400">
+              Select which team members should have access to this board. Only selected members will be able to view and edit notes in this board.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Search Box */}
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Search className="h-4 w-4 text-muted-foreground dark:text-zinc-400" />
+            </div>
+            <Input
+              placeholder="Search team members..."
+              value={memberSearchTerm}
+              onChange={(e) => setMemberSearchTerm(e.target.value)}
+              className="pl-10 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
+            />
+          </div>
+
+          {/* Member List */}
+          <div className="space-y-3 max-h-96 overflow-y-auto">
+            {boardSharing
+              .filter(member =>
+                memberSearchTerm === "" ||
+                (member.name || member.email).toLowerCase().includes(memberSearchTerm.toLowerCase())
+              )
+              .map((member) => (
+                <div
+                  key={member.id}
+                  className="flex items-center justify-between p-3 bg-zinc-50 dark:bg-zinc-800 rounded-lg"
+                >
+                  <div className="flex items-center space-x-3">
+                    <div className="w-8 h-8 bg-blue-500 dark:bg-zinc-700 rounded-full flex items-center justify-center text-white text-sm font-medium">
+                      {(member.name || member.email).charAt(0).toUpperCase()}
+                    </div>
+                    <div>
+                      <p className="font-medium text-zinc-900 dark:text-zinc-100">
+                        {member.name || "Unnamed User"}
+                      </p>
+                      <p className="text-sm text-zinc-600 dark:text-zinc-400">{member.email}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Switch
+                      checked={member.isShared}
+                      onCheckedChange={(checked) => handleToggleMemberSharing(member.id, checked)}
+                      disabled={updatingSharing === member.id || updatingSharing === "bulk"}
+                      className="data-[state=checked]:bg-green-600"
+                    />
+                    <span className="text-sm text-zinc-600 dark:text-zinc-400">
+                      {member.isShared ? "Shared" : "Not shared"}
+                    </span>
+                  </div>
+                </div>
+              ))}
+          </div>
+
+          {/* Summary */}
+          <div className="flex justify-between items-center pt-4 border-t border-zinc-200 dark:border-zinc-800">
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">
+              {boardSharing.filter(member => member.isShared).length} of {boardSharing.length} members have access
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => setBoardSharingDialog(false)}
+              disabled={updatingSharing === "bulk"}
+            >
+              Done
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={deleteConfirmDialog} onOpenChange={setDeleteConfirmDialog}>

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -43,7 +43,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 
 import { useUser } from "@/app/contexts/UserContext";
@@ -129,7 +128,6 @@ export default function OrganizationSettingsPage() {
   const [copiedInviteToken, setCopiedInviteToken] = useState<string | null>(null);
   const [membersWithSharing, setMembersWithSharing] = useState<MemberWithSharing[]>([]);
   const [boards, setBoards] = useState<Board[]>([]);
-  const [loadingSharing, setLoadingSharing] = useState(false);
   const [updatingSharing, setUpdatingSharing] = useState<string | null>(null);
   const [boardDialog, setBoardDialog] = useState<{
     open: boolean;
@@ -188,7 +186,6 @@ export default function OrganizationSettingsPage() {
   };
 
   const fetchBoardSharing = async () => {
-    setLoadingSharing(true);
     try {
       const response = await fetch("/api/organization/share");
       if (response.ok) {
@@ -199,7 +196,6 @@ export default function OrganizationSettingsPage() {
     } catch (error) {
       console.error("Error fetching board sharing:", error);
     } finally {
-      setLoadingSharing(false);
     }
   };
 

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -208,10 +208,12 @@ export default function OrganizationSettingsPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          userSharing: [{
-            userId: memberId,
-            shareAllBoards,
-          }],
+          userSharing: [
+            {
+              userId: memberId,
+              shareAllBoards,
+            },
+          ],
         }),
       });
 
@@ -246,11 +248,13 @@ export default function OrganizationSettingsPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          userSharing: [{
-            userId: memberId,
-            shareAllBoards: sharedBoardIds.length === boards.length,
-            sharedBoardIds,
-          }],
+          userSharing: [
+            {
+              userId: memberId,
+              shareAllBoards: sharedBoardIds.length === boards.length,
+              sharedBoardIds,
+            },
+          ],
         }),
       });
 
@@ -737,7 +741,7 @@ export default function OrganizationSettingsPage() {
 
           <div className="space-y-3 truncate max-w-full overflow-hidden whitespace-nowrap">
             {user?.organization?.members?.map((member) => {
-              const memberSharing = membersWithSharing.find(m => m.id === member.id);
+              const memberSharing = membersWithSharing.find((m) => m.id === member.id);
               return (
                 <div
                   key={member.id}
@@ -748,7 +752,9 @@ export default function OrganizationSettingsPage() {
                       <AvatarImage src={member.image || ""} alt={member.name || member.email} />
                       <AvatarFallback
                         className={
-                          member.isAdmin ? "bg-purple-500" : "bg-blue-500 dark:bg-zinc-700 text-white"
+                          member.isAdmin
+                            ? "bg-purple-500"
+                            : "bg-blue-500 dark:bg-zinc-700 text-white"
                         }
                       >
                         {member.name
@@ -786,7 +792,9 @@ export default function OrganizationSettingsPage() {
                       <div className="flex items-center space-x-2">
                         <Switch
                           checked={memberSharing?.shareAllBoards || false}
-                          onCheckedChange={(checked) => handleToggleShareAllBoards(member.id, checked)}
+                          onCheckedChange={(checked) =>
+                            handleToggleShareAllBoards(member.id, checked)
+                          }
                           disabled={updatingSharing === member.id}
                           className="data-[state=checked]:bg-green-600"
                         />
@@ -794,7 +802,13 @@ export default function OrganizationSettingsPage() {
                           Share all boards
                         </span>
                         <Button
-                          onClick={() => openBoardDialog(member.id, member.name || member.email, memberSharing?.sharedBoardIds || [])}
+                          onClick={() =>
+                            openBoardDialog(
+                              member.id,
+                              member.name || member.email,
+                              memberSharing?.sharedBoardIds || []
+                            )
+                          }
                           variant="outline"
                           size="sm"
                           className="text-zinc-500 dark:text-zinc-400 hover:text-zinc-600 hover:bg-zinc-50 dark:hover:text-zinc-300 dark:hover:bg-zinc-800"
@@ -1182,29 +1196,38 @@ export default function OrganizationSettingsPage() {
       </AlertDialog>
 
       {/* Board Sharing Dialog */}
-      <Dialog open={boardDialog.open} onOpenChange={(open) => setBoardDialog({ open, memberId: "", memberName: "", sharedBoardIds: [] })}>
+      <Dialog
+        open={boardDialog.open}
+        onOpenChange={(open) =>
+          setBoardDialog({ open, memberId: "", memberName: "", sharedBoardIds: [] })
+        }
+      >
         <DialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 max-w-2xl">
           <DialogHeader>
             <DialogTitle className="text-foreground dark:text-zinc-100">
               Share boards with {boardDialog.memberName}
             </DialogTitle>
             <DialogDescription className="text-muted-foreground dark:text-zinc-400">
-              Select which boards to share with this team member. They will only be able to see and edit the selected boards.
+              Select which boards to share with this team member. They will only be able to see and
+              edit the selected boards.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 max-h-96 overflow-y-auto">
             {boards.map((board) => {
               const isShared = boardDialog.sharedBoardIds.includes(board.id);
               return (
-                <div key={board.id} className="flex items-center space-x-3 p-3 bg-zinc-50 dark:bg-zinc-800 rounded-lg">
+                <div
+                  key={board.id}
+                  className="flex items-center space-x-3 p-3 bg-zinc-50 dark:bg-zinc-800 rounded-lg"
+                >
                   <Checkbox
                     id={`board-${board.id}`}
                     checked={isShared}
                     onCheckedChange={(checked) => {
                       const newSharedBoardIds = checked
                         ? [...boardDialog.sharedBoardIds, board.id]
-                        : boardDialog.sharedBoardIds.filter(id => id !== board.id);
-                      setBoardDialog(prev => ({ ...prev, sharedBoardIds: newSharedBoardIds }));
+                        : boardDialog.sharedBoardIds.filter((id) => id !== board.id);
+                      setBoardDialog((prev) => ({ ...prev, sharedBoardIds: newSharedBoardIds }));
                     }}
                     className="data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
                   />
@@ -1225,13 +1248,17 @@ export default function OrganizationSettingsPage() {
             <div className="flex space-x-2">
               <Button
                 variant="outline"
-                onClick={() => setBoardDialog({ open: false, memberId: "", memberName: "", sharedBoardIds: [] })}
+                onClick={() =>
+                  setBoardDialog({ open: false, memberId: "", memberName: "", sharedBoardIds: [] })
+                }
                 disabled={updatingSharing === boardDialog.memberId}
               >
                 Cancel
               </Button>
               <Button
-                onClick={() => handleUpdateBoardSharing(boardDialog.memberId, boardDialog.sharedBoardIds)}
+                onClick={() =>
+                  handleUpdateBoardSharing(boardDialog.memberId, boardDialog.sharedBoardIds)
+                }
                 disabled={updatingSharing === boardDialog.memberId}
                 className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-700 dark:hover:bg-blue-800"
               >

--- a/prisma/migrations/20251005180754_add_board_shares/migration.sql
+++ b/prisma/migrations/20251005180754_add_board_shares/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "board_shares" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "board_shares_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "board_shares_boardId_idx" ON "board_shares"("boardId");
+
+-- CreateIndex
+CREATE INDEX "board_shares_userId_idx" ON "board_shares"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "board_shares_boardId_userId_key" ON "board_shares"("boardId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "board_shares" ADD CONSTRAINT "board_shares_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "boards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "board_shares" ADD CONSTRAINT "board_shares_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   invitedOrganizations OrganizationInvite[]
   createdSelfServeInvites OrganizationSelfServeInvite[]
   notes          Note[]
+  boardShares    BoardShare[]
 
   @@index([organizationId], name: "idx_user_org")
   @@map("users")
@@ -94,6 +95,7 @@ model Board {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
   notes          Note[]
+  shares         BoardShare[]
 
   // Performance indexes
   @@index([organizationId, createdAt], name: "idx_board_org_created")
@@ -135,6 +137,20 @@ model ChecklistItem {
   @@map("checklist_items")
   @@index([noteId])
   @@index([noteId, order])
+}
+
+model BoardShare {
+  id        String   @id @default(cuid())
+  boardId   String
+  userId    String
+  board     Board    @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  @@unique([boardId, userId])
+  @@map("board_shares")
+  @@index([boardId])
+  @@index([userId])
 }
 
 model OrganizationInvite {

--- a/tests/e2e/board-sharing.spec.ts
+++ b/tests/e2e/board-sharing.spec.ts
@@ -1,0 +1,362 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Board Sharing", () => {
+  test.beforeEach(async ({ testPrisma, testContext }) => {
+    // Make the test user an admin
+    await testPrisma.user.update({
+      where: { id: testContext.userId },
+      data: { isAdmin: true },
+    });
+
+    // Create a second user for sharing tests
+    const secondUserId = `usr2_${testContext.testId}`;
+    const secondUserEmail = `test2-${testContext.testId}@example.com`;
+
+    await testPrisma.user.create({
+      data: {
+        id: secondUserId,
+        email: secondUserEmail,
+        name: `Test User 2 ${testContext.testId}`,
+        organizationId: testContext.organizationId,
+        isAdmin: false,
+      },
+    });
+  });
+
+  test.describe("Board Creation & Creator Access", () => {
+    test("admin creates board with auto-access", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      await authenticatedPage.goto("/dashboard");
+
+      const boardName = testContext.getBoardName("Shared Test Board");
+      await authenticatedPage.click('button:has-text("Add Board")');
+      await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
+      await authenticatedPage.fill('textarea[placeholder*="board description"]', "Test board for sharing");
+
+      const createResponse = authenticatedPage.waitForResponse(
+        (resp) => resp.url().includes("/api/boards") && resp.status() === 201
+      );
+
+      await authenticatedPage.click('button:has-text("Create board")');
+      await createResponse;
+
+      // Verify board in dashboard
+      await expect(
+        authenticatedPage.locator(`[data-slot="card-title"]:has-text("${boardName}")`)
+      ).toBeVisible();
+
+      // Verify board in database
+      const board = await testPrisma.board.findFirst({
+        where: {
+          name: boardName,
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+      expect(board).toBeTruthy();
+
+      // Verify creator auto-shared
+      const boardShare = await testPrisma.boardShare.findFirst({
+        where: {
+          boardId: board!.id,
+          userId: testContext.userId,
+        },
+      });
+      expect(boardShare).toBeTruthy();
+    });
+
+    test("creator can access own board", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Creator Access Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for creator access",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      // Navigate to board
+      await authenticatedPage.goto(`/boards/${board.id}`);
+
+      // Should load successfully
+      await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
+      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+    });
+  });
+
+  test.describe("Board Sharing Dialog", () => {
+    test("sharing dialog shows creator identification", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Sharing Dialog Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for sharing dialog",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await authenticatedPage.click('[aria-label="Board settings"]');
+      await authenticatedPage.click('button:has-text("Manage Sharing")');
+
+      // Dialog opens
+      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+
+      // Creator identified with badge and auto-access
+      await expect(authenticatedPage.locator("text=Creator")).toBeVisible();
+      await expect(authenticatedPage.locator("text=Auto access")).toBeVisible();
+    });
+
+    test("sharing dialog shows all members", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Members Dialog Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for members dialog",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await authenticatedPage.click('[aria-label="Board settings"]');
+      await authenticatedPage.click('button:has-text("Manage Sharing")');
+
+      // Shows all org members
+      await expect(authenticatedPage.locator("text=Test User").first()).toBeVisible(); // Admin
+      await expect(authenticatedPage.locator("text=Test User 2")).toBeVisible(); // Regular user
+    });
+
+    test("dialog persists during member toggles", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Toggle Dialog Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for toggle dialog",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await authenticatedPage.click('[aria-label="Board settings"]');
+      await authenticatedPage.click('button:has-text("Manage Sharing")');
+
+      // Toggle member sharing
+      const toggleSwitch = authenticatedPage.locator('button[role="switch"]').nth(1); // Second member
+      await toggleSwitch.click();
+
+      // Dialog stays open
+      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+
+      // Can toggle again
+      await toggleSwitch.click();
+      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+    });
+
+    test("dialog closes on Done button", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Done Button Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for done button",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await authenticatedPage.click('[aria-label="Board settings"]');
+      await authenticatedPage.click('button:has-text("Manage Sharing")');
+
+      // Dialog opens
+      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+
+      // Click Done
+      await authenticatedPage.click('[data-slot="dialog-content"] button:has-text("Done")');
+
+      // Dialog closes
+      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).not.toBeVisible();
+    });
+  });
+
+  test.describe("Access Control", () => {
+    test("shared user can access board", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Shared Access Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for shared access",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      // Share with second user
+      await testPrisma.boardShare.create({
+        data: {
+          boardId: board.id,
+          userId: `usr2_${testContext.testId}`,
+        },
+      });
+
+      // Verify sharing record exists
+      const boardShare = await testPrisma.boardShare.findFirst({
+        where: {
+          boardId: board.id,
+          userId: `usr2_${testContext.testId}`,
+        },
+      });
+      expect(boardShare).toBeTruthy();
+    });
+
+    test("creator has access without explicit sharing", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board without sharing
+      const boardName = testContext.getBoardName("Creator Access Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for creator access without explicit sharing",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      // Creator can access own board
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
+      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+    });
+
+  });
+
+  test.describe("Organization Integration", () => {
+    test("org sharing API works", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board
+      const boardName = testContext.getBoardName("Org Sync Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for org sync",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      await authenticatedPage.goto("/settings/organization");
+
+      // Verify org sharing API
+      const orgShareResponse = await authenticatedPage.request.get("/api/organization/share");
+      expect(orgShareResponse.ok()).toBeTruthy();
+
+      const shareData = await orgShareResponse.json();
+      expect(shareData.members).toBeDefined();
+      expect(shareData.boards).toBeDefined();
+    });
+  });
+
+  test.describe("Edge Cases", () => {
+    test("public boards are accessible", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create public board
+      const boardName = testContext.getBoardName("Public Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test public board",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+          isPublic: true,
+        },
+      });
+
+      // Public boards accessible
+      await authenticatedPage.goto(`/boards/${board.id}`);
+      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+    });
+
+    test("board deletion removes sharing", async ({
+      authenticatedPage,
+      testContext,
+      testPrisma,
+    }) => {
+      // Create board with sharing
+      const boardName = testContext.getBoardName("Deletion Test Board");
+      const board = await testPrisma.board.create({
+        data: {
+          name: boardName,
+          description: "Test board for deletion",
+          createdBy: testContext.userId,
+          organizationId: testContext.organizationId,
+        },
+      });
+
+      // Share with second user
+      await testPrisma.boardShare.create({
+        data: {
+          boardId: board.id,
+          userId: `usr2_${testContext.testId}`,
+        },
+      });
+
+      // Delete board
+      await testPrisma.board.delete({
+        where: { id: board.id },
+      });
+
+      // Sharing record deleted (cascade)
+      const boardShare = await testPrisma.boardShare.findFirst({
+        where: {
+          boardId: board.id,
+        },
+      });
+      expect(boardShare).toBeNull();
+    });
+  });
+});

--- a/tests/e2e/board-sharing.spec.ts
+++ b/tests/e2e/board-sharing.spec.ts
@@ -34,7 +34,10 @@ test.describe("Board Sharing", () => {
       const boardName = testContext.getBoardName("Shared Test Board");
       await authenticatedPage.click('button:has-text("Add Board")');
       await authenticatedPage.fill('input[placeholder*="board name"]', boardName);
-      await authenticatedPage.fill('textarea[placeholder*="board description"]', "Test board for sharing");
+      await authenticatedPage.fill(
+        'textarea[placeholder*="board description"]',
+        "Test board for sharing"
+      );
 
       const createResponse = authenticatedPage.waitForResponse(
         (resp) => resp.url().includes("/api/boards") && resp.status() === 201
@@ -68,11 +71,7 @@ test.describe("Board Sharing", () => {
       expect(boardShare).toBeTruthy();
     });
 
-    test("creator can access own board", async ({
-      authenticatedPage,
-      testContext,
-      testPrisma,
-    }) => {
+    test("creator can access own board", async ({ authenticatedPage, testContext, testPrisma }) => {
       // Create board
       const boardName = testContext.getBoardName("Creator Access Board");
       const board = await testPrisma.board.create({
@@ -89,7 +88,11 @@ test.describe("Board Sharing", () => {
 
       // Should load successfully
       await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
-      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+      await expect(
+        authenticatedPage
+          .locator(`[data-testid="board-dropdown-trigger"]`)
+          .filter({ hasText: boardName })
+      ).toBeVisible();
     });
   });
 
@@ -115,7 +118,9 @@ test.describe("Board Sharing", () => {
       await authenticatedPage.click('button:has-text("Manage Sharing")');
 
       // Dialog opens
-      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })
+      ).toBeVisible();
 
       // Creator identified with badge and auto-access
       await expect(authenticatedPage.locator("text=Creator")).toBeVisible();
@@ -172,18 +177,18 @@ test.describe("Board Sharing", () => {
       await toggleSwitch.click();
 
       // Dialog stays open
-      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })
+      ).toBeVisible();
 
       // Can toggle again
       await toggleSwitch.click();
-      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })
+      ).toBeVisible();
     });
 
-    test("dialog closes on Done button", async ({
-      authenticatedPage,
-      testContext,
-      testPrisma,
-    }) => {
+    test("dialog closes on Done button", async ({ authenticatedPage, testContext, testPrisma }) => {
       // Create board
       const boardName = testContext.getBoardName("Done Button Board");
       const board = await testPrisma.board.create({
@@ -200,22 +205,22 @@ test.describe("Board Sharing", () => {
       await authenticatedPage.click('button:has-text("Manage Sharing")');
 
       // Dialog opens
-      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })
+      ).toBeVisible();
 
       // Click Done
       await authenticatedPage.click('[data-slot="dialog-content"] button:has-text("Done")');
 
       // Dialog closes
-      await expect(authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })).not.toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-slot="dialog-title"]').filter({ hasText: "Share" })
+      ).not.toBeVisible();
     });
   });
 
   test.describe("Access Control", () => {
-    test("shared user can access board", async ({
-      authenticatedPage,
-      testContext,
-      testPrisma,
-    }) => {
+    test("shared user can access board", async ({ authenticatedPage, testContext, testPrisma }) => {
       // Create board
       const boardName = testContext.getBoardName("Shared Access Board");
       const board = await testPrisma.board.create({
@@ -264,17 +269,16 @@ test.describe("Board Sharing", () => {
       // Creator can access own board
       await authenticatedPage.goto(`/boards/${board.id}`);
       await expect(authenticatedPage.locator("text=Board not found")).not.toBeVisible();
-      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+      await expect(
+        authenticatedPage
+          .locator(`[data-testid="board-dropdown-trigger"]`)
+          .filter({ hasText: boardName })
+      ).toBeVisible();
     });
-
   });
 
   test.describe("Organization Integration", () => {
-    test("org sharing API works", async ({
-      authenticatedPage,
-      testContext,
-      testPrisma,
-    }) => {
+    test("org sharing API works", async ({ authenticatedPage, testContext, testPrisma }) => {
       // Create board
       const boardName = testContext.getBoardName("Org Sync Board");
       const board = await testPrisma.board.create({
@@ -299,11 +303,7 @@ test.describe("Board Sharing", () => {
   });
 
   test.describe("Edge Cases", () => {
-    test("public boards are accessible", async ({
-      authenticatedPage,
-      testContext,
-      testPrisma,
-    }) => {
+    test("public boards are accessible", async ({ authenticatedPage, testContext, testPrisma }) => {
       // Create public board
       const boardName = testContext.getBoardName("Public Board");
       const board = await testPrisma.board.create({
@@ -318,7 +318,11 @@ test.describe("Board Sharing", () => {
 
       // Public boards accessible
       await authenticatedPage.goto(`/boards/${board.id}`);
-      await expect(authenticatedPage.locator(`[data-testid="board-dropdown-trigger"]`).filter({ hasText: boardName })).toBeVisible();
+      await expect(
+        authenticatedPage
+          .locator(`[data-testid="board-dropdown-trigger"]`)
+          .filter({ hasText: boardName })
+      ).toBeVisible();
     });
 
     test("board deletion removes sharing", async ({


### PR DESCRIPTION
fixes #822 
## Board-Level Sharing Permissions

Implemented granular board sharing controls that allow organization admins to share specific boards with team members, rather than giving access to all boards.

### Approach
- Added board-level sharing toggles in organization settings with `Share all boards` option
- Included granular board selection via `View` button for precise control
- Implemented board settings with member search and individual sharing toggles
- Ensured synchronization between organization and board-level settings


https://github.com/user-attachments/assets/45d6b7d3-48eb-4696-a2d7-308f1d34d1a1


### Changes
- **Database**: Added `BoardShare` model for granular permissions
- **API**: Created board sharing management endpoints with authorization logic
- **UI**: Built sharing dialogs in organization and board settings
- **Authorization**: Updated access control to check board-level permissions
- **Tests**: Added comprehensive e2e tests covering all sharing scenarios

### AI Disclosure
- used claude sonnet 4.5

### Screenshots

#### **Org Settings**

<table>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/d08da331-7352-4f30-bfc5-9c451a106136" width="400"/></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/688a63a9-9599-4aad-ad65-8563a5200b68" width="400"/></td>
  </tr>
</table>

#### **Board Settings**

<table>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/276a9742-45c4-49a9-b30f-96dab1c5a7ab" width="300"/></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/2a3734e6-f6cf-43f7-80dd-9a77e07b7cd0" width="300"/></td>
  </tr>
</table>


